### PR TITLE
refactor: 优化设备消息发送逻辑

### DIFF
--- a/src/main/java/org/jetlinks/supports/device/session/ClusterDeviceSessionManager.java
+++ b/src/main/java/org/jetlinks/supports/device/session/ClusterDeviceSessionManager.java
@@ -83,7 +83,7 @@ public class ClusterDeviceSessionManager extends AbstractDeviceSessionManager {
         Flux<DeviceSessionInfo> sessions();
 
         @ServiceMethod
-        Flux<DeviceSessionInfo> sessions(String deviceId);
+        Flux<DeviceSessionInfo> deviceSessions(String deviceId);
 
         @ServiceMethod
         Mono<Void> sync(DeviceSessionInfo info);
@@ -208,7 +208,7 @@ public class ClusterDeviceSessionManager extends AbstractDeviceSessionManager {
         }
 
         @Override
-        public Flux<DeviceSessionInfo> sessions(String deviceId) {
+        public Flux<DeviceSessionInfo> deviceSessions(String deviceId) {
             return doWith(deviceId,
                           AbstractDeviceSessionManager::getLocalDeviceSessionInfo,
                           Flux.empty());
@@ -443,9 +443,9 @@ public class ClusterDeviceSessionManager extends AbstractDeviceSessionManager {
         }
 
         @Override
-        public Flux<DeviceSessionInfo> sessions(String deviceId) {
+        public Flux<DeviceSessionInfo> deviceSessions(String deviceId) {
             return service
-                .sessions(deviceId)
+                .deviceSessions(deviceId)
                 .onErrorResume(err -> {
                     handleError(err);
                     return Flux.empty();
@@ -534,7 +534,7 @@ public class ClusterDeviceSessionManager extends AbstractDeviceSessionManager {
     @Override
     protected Flux<DeviceSessionInfo> remoteDeviceSessions(String deviceId) {
         return getServices()
-            .flatMap(service->service.sessions(deviceId));
+            .flatMap(service->service.deviceSessions(deviceId));
     }
 
     private Flux<Service> getServices() {

--- a/src/main/java/org/jetlinks/supports/device/session/ClusterDeviceSessionManager.java
+++ b/src/main/java/org/jetlinks/supports/device/session/ClusterDeviceSessionManager.java
@@ -83,6 +83,9 @@ public class ClusterDeviceSessionManager extends AbstractDeviceSessionManager {
         Flux<DeviceSessionInfo> sessions();
 
         @ServiceMethod
+        Flux<DeviceSessionInfo> sessions(String deviceId);
+
+        @ServiceMethod
         Mono<Void> sync(DeviceSessionInfo info);
 
         @Getter
@@ -202,6 +205,13 @@ public class ClusterDeviceSessionManager extends AbstractDeviceSessionManager {
             return doWith(deviceId,
                           AbstractDeviceSessionManager::removeFromCluster,
                           Reactors.ALWAYS_ZERO_LONG);
+        }
+
+        @Override
+        public Flux<DeviceSessionInfo> sessions(String deviceId) {
+            return doWith(deviceId,
+                          AbstractDeviceSessionManager::getLocalDeviceSessionInfo,
+                          Flux.empty());
         }
 
         @Override
@@ -431,6 +441,16 @@ public class ClusterDeviceSessionManager extends AbstractDeviceSessionManager {
             return service
                 .sync(info);
         }
+
+        @Override
+        public Flux<DeviceSessionInfo> sessions(String deviceId) {
+            return service
+                .sessions(deviceId)
+                .onErrorResume(err -> {
+                    handleError(err);
+                    return Flux.empty();
+                });
+        }
     }
 
 
@@ -509,6 +529,12 @@ public class ClusterDeviceSessionManager extends AbstractDeviceSessionManager {
         }
         Service service = services.get(serverId);
         return service == null ? Flux.empty() : service.sessions();
+    }
+
+    @Override
+    protected Flux<DeviceSessionInfo> remoteDeviceSessions(String deviceId) {
+        return getServices()
+            .flatMap(service->service.sessions(deviceId));
     }
 
     private Flux<Service> getServices() {

--- a/src/main/java/org/jetlinks/supports/device/session/LocalDeviceSessionManager.java
+++ b/src/main/java/org/jetlinks/supports/device/session/LocalDeviceSessionManager.java
@@ -46,4 +46,9 @@ public class LocalDeviceSessionManager extends AbstractDeviceSessionManager {
     protected Flux<DeviceSessionInfo> remoteSessions(String serverId) {
         return Flux.empty();
     }
+
+    @Override
+    protected Flux<DeviceSessionInfo> remoteDeviceSessions(String deviceId) {
+        return Flux.empty();
+    }
 }

--- a/src/main/java/org/jetlinks/supports/server/ClientMessageHandler.java
+++ b/src/main/java/org/jetlinks/supports/server/ClientMessageHandler.java
@@ -5,6 +5,7 @@ import org.jetlinks.core.message.codec.MessageDecodeContext;
 import org.jetlinks.core.message.codec.Transport;
 import reactor.core.publisher.Mono;
 
+@Deprecated
 public interface ClientMessageHandler {
     Mono<Boolean> handleMessage(DeviceOperator operator, Transport transport, MessageDecodeContext message);
 

--- a/src/main/java/org/jetlinks/supports/server/ClusterSendToDeviceMessageHandler.java
+++ b/src/main/java/org/jetlinks/supports/server/ClusterSendToDeviceMessageHandler.java
@@ -15,6 +15,7 @@ import org.jetlinks.core.message.state.DeviceStateCheckMessage;
 import org.jetlinks.core.server.MessageHandler;
 import org.jetlinks.core.server.session.ChildrenDeviceSession;
 import org.jetlinks.core.server.session.DeviceSession;
+import org.jetlinks.core.server.session.DeviceSessionSelector;
 import org.jetlinks.core.server.session.LostDeviceSession;
 import org.jetlinks.core.trace.TraceHolder;
 import org.jetlinks.core.utils.Reactors;
@@ -31,7 +32,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 @Slf4j
-public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono<Void>> {
+public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono<Integer>> {
 
     private static final HeaderKey<Boolean> resumeSession = HeaderKey.of("resume-session", true);
 
@@ -74,25 +75,24 @@ public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono
         return TraceHolder.copyContext(message.getHeaders(), reply, Message::addHeaderIfAbsent);
     }
 
-    private Mono<Void> handleMessage(Message msg) {
-        //异步发送
-        if (msg.getHeaderOrDefault(Headers.async)) {
-            return Mono.deferContextual(ctx -> {
-                @SuppressWarnings("all")
-                Disposable disposable = handleMessage0(msg)
-                    .subscribe(null, null, null, Context.of(ctx));
-                return Mono.empty();
-            });
-        }
+    private Mono<Integer> handleMessage(Message msg) {
+//        //异步发送
+//        if (msg.getHeaderOrDefault(Headers.async)) {
+//            return Mono.deferContextual(ctx -> {
+//                @SuppressWarnings("all")
+//                Disposable disposable = handleMessage0(msg)
+//                    .subscribe(null, null, null, Context.of(ctx));
+//                return Reactors.ALWAYS_ONE;
+//            });
+//        }
         return handleMessage0(msg);
     }
 
-    private Mono<Void> handleMessage0(Message msg) {
-        if (!(msg instanceof DeviceMessage)) {
+    private Mono<Integer> handleMessage0(Message msg) {
+        if (!(msg instanceof DeviceMessage message)) {
             return Mono.empty();
         }
 
-        DeviceMessage message = ((DeviceMessage) msg);
         if (message.getDeviceId() == null) {
             log.warn("deviceId is null :{}", message);
             return Mono.empty();
@@ -108,7 +108,7 @@ public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono
     }
 
     @SuppressWarnings("all")
-    private Mono<Void> sendTo(DeviceSession session, DeviceMessage message) {
+    private Mono<Integer> sendTo(DeviceSession session, DeviceMessage message) {
         DeviceOperator device;
         //子设备会话都发给网关
         if (session.isWrapFrom(ChildrenDeviceSession.class)) {
@@ -124,7 +124,7 @@ public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono
                 return sessionManager
                     .remove(session.getDeviceId(), false)
                     .then(
-                        doReply(device, ((DisconnectDeviceMessage) message).newReply().success())
+                        doReply(device, ((DisconnectDeviceMessage) message).newReply().success()).then(Reactors.ALWAYS_ONE)
                     );
             }
             return retryResume(device, message);
@@ -132,12 +132,18 @@ public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono
 
         CodecContext context = new CodecContext(device, message, DeviceSession.trace(session));
 
-        return Mono
+        Mono<Integer> sender =  Mono
             //交给会话处理
             .defer(() -> session.send(context))
-            .filter(Boolean::booleanValue)
-            //返回false或者empty,可能是不支持这类消息
-            .switchIfEmpty(Mono.defer(() -> handleUnsupportedMessage(context).then(Mono.empty())))
+            .defaultIfEmpty(false)
+            .flatMap(success -> {
+                if (!success) {
+                    // 发送失败了?
+                    return handleUnsupportedMessage(context);
+                } else {
+                    return Reactors.ALWAYS_ONE;
+                }
+            })
             //发送消息异常
             .onErrorResume(err -> {
                 if (!(err instanceof DeviceOperationException)) {
@@ -146,11 +152,22 @@ public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono
                 if (!context.alreadyReply) {
                     return this
                         .doReply(context, createReply(context.message).error(err))
-                        .then(Mono.empty());
+                        .then(Reactors.ALWAYS_ONE);
                 }
-                return Mono.empty();
+                return Reactors.ALWAYS_ONE;
             })
-            .then(Mono.defer(() -> handleMessageSent(context)));
+            .flatMap(num -> handleMessageSent(context).thenReturn(num));
+
+        //异步发送
+        if (message.getHeaderOrDefault(Headers.async)) {
+            return Mono.deferContextual(ctx -> {
+                @SuppressWarnings("all")
+                Disposable disposable =sender
+                    .subscribe(null, null, null, Context.of(ctx));
+                return Reactors.ALWAYS_ONE;
+            });
+        }
+        return sender;
 
     }
 
@@ -170,43 +187,48 @@ public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono
         return Mono.empty();
     }
 
-    private Mono<Void> handleUnsupportedMessage(CodecContext context) {
+    private Mono<Integer> handleUnsupportedMessage(CodecContext context) {
         // 已经发送给了设备,则认为已经处理
-        if(context.alreadySent){
-            return Mono.empty();
+        if (context.alreadySent) {
+            return Reactors.ALWAYS_ONE;
         }
         if (!context.alreadyReply) {
             //断开连接
             if (context.message instanceof DisconnectDeviceMessage) {
                 return sessionManager
                     .remove(context.device.getDeviceId(), false)
-                    .then(Mono.defer(() -> this.doReply(context, this.createReply(context.message).success())));
+                    .then(Mono.defer(() -> this.doReply(context, this.createReply(context.message).success())))
+                    .then(Reactors.ALWAYS_ONE);
             }
 
             //子设备消息
-            if (context.message instanceof ChildDeviceMessage) {
-                ChildDeviceMessage child = ((ChildDeviceMessage) context.message);
+            if (context.message instanceof ChildDeviceMessage child) {
                 Message childMsg = child.getChildDeviceMessage();
                 //断开子设备连接
                 if (childMsg instanceof DisconnectDeviceMessage) {
                     return sessionManager
                         .remove(((DisconnectDeviceMessage) childMsg).getDeviceId(), false)
-                        .then(Mono.defer(() -> this.doReply(context, this.createReply(context.message).success())));
+                        .then(Mono.defer(() -> this.doReply(context, this.createReply(context.message).success())))
+                        .then(Reactors.ALWAYS_ONE);
                 }
                 //获取子设备状态
                 if (childMsg instanceof DeviceStateCheckMessage) {
-                    return this.doReply(context, this.createReply(context.message).success());
+                    return this.doReply(context, this.createReply(context.message).success())
+                               .then(Reactors.ALWAYS_ONE);
                 }
             }
             //不支持
-            return this.doReply(context, this.createReply(context.message).error(ErrorCode.UNSUPPORTED_MESSAGE));
+            return this
+                .doReply(context, this.createReply(context.message).error(ErrorCode.UNSUPPORTED_MESSAGE))
+                .then(Reactors.ALWAYS_ONE);
         }
 
-        return Mono.empty();
+        // 不支持的消息,认为并没有发送成功?
+        return Reactors.ALWAYS_ZERO;
 
     }
 
-    private Mono<Void> sendToUnknownSession(DeviceMessage message) {
+    private Mono<Integer> sendToUnknownSession(DeviceMessage message) {
         return registry
             .getDevice(message.getDeviceId())
             .flatMap(device -> device
@@ -218,7 +240,7 @@ public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono
             .flatMap(Function.identity());
     }
 
-    private Mono<Void> sendToNoSession(DeviceOperator device, DeviceMessage message) {
+    private Mono<Integer> sendToNoSession(DeviceOperator device, DeviceMessage message) {
         return sessionManager
             //检查整个集群的会话
             .checkAlive(message.getDeviceId(), false)
@@ -232,34 +254,39 @@ public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono
                 boolean resume = message.getHeader(resumeSession).orElse(false);
                 return doReply(device, createReply(message)
                     .addHeader("reason", "session_not_exists")
-                    .error(resume ? ErrorCode.CONNECTION_LOST : ErrorCode.CLIENT_OFFLINE));
+                    .error(resume ? ErrorCode.CONNECTION_LOST : ErrorCode.CLIENT_OFFLINE))
+                    .then(Reactors.ALWAYS_ZERO);
             });
     }
 
-    private Mono<Void> retryResume(DeviceOperator device, DeviceMessage message) {
+    private Mono<Integer> retryResume(DeviceOperator device, DeviceMessage message) {
         //防止递归
         if (message.getHeader(resumeSession).isPresent()) {
-            return doReply(device, createReply(message).error(ErrorCode.CONNECTION_LOST));
+            return doReply(device, createReply(message).error(ErrorCode.CONNECTION_LOST))
+                .then(Reactors.ALWAYS_ZERO);
         }
         message.addHeader(resumeSession, true);
+        boolean latest = message.getHeaderOrDefault(Headers.sessionSelector) == DeviceSessionSelector.any;
         //尝试发送给其他节点
-        if (handler instanceof DeviceOperationBroker) {
+        if (latest && handler instanceof DeviceOperationBroker) {
             return device
                 .getSelfConfig(DeviceConfigKey.connectionServerId)
                 .flatMap(serverId -> ((DeviceOperationBroker) handler).send(serverId, Mono.just(message)))
                 .flatMap(i -> {
                     if (i > 0) {
-                        return Mono.empty();
+                        return Mono.just(i);
                     }
-                    return doReply(device, createReply(message).error(ErrorCode.CONNECTION_LOST));
+                    return doReply(device, createReply(message).error(ErrorCode.CONNECTION_LOST))
+                        .then(Reactors.ALWAYS_ZERO);
                 });
         }
-        return doReply(device, createReply(message).error(ErrorCode.CONNECTION_LOST));
+        return doReply(device, createReply(message).error(ErrorCode.CONNECTION_LOST))
+            .then(Reactors.ALWAYS_ZERO);
     }
 
-    private Mono<Void> sendToParentSession(DeviceOperator device,
-                                           DeviceOperator parent,
-                                           DeviceMessage message) {
+    private Mono<Integer> sendToParentSession(DeviceOperator device,
+                                              DeviceOperator parent,
+                                              DeviceMessage message) {
 
         ChildDeviceMessage child = new ChildDeviceMessage();
         child.setDeviceId(parent.getDeviceId());
@@ -293,7 +320,7 @@ public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono
     }
 
     @Override
-    public Mono<Void> apply(Message message) {
+    public Mono<Integer> apply(Message message) {
         return handleMessage(message);
     }
 
@@ -302,7 +329,7 @@ public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono
         private final DeviceMessage message;
         private final DeviceSession session;
 
-        private volatile boolean alreadyReply = false,alreadySent = false;
+        private volatile boolean alreadyReply = false, alreadySent = false;
 
         CodecContext(DeviceOperator device, DeviceMessage message, DeviceSession session) {
             this.device = device;

--- a/src/main/java/org/jetlinks/supports/server/DecodedClientMessageHandler.java
+++ b/src/main/java/org/jetlinks/supports/server/DecodedClientMessageHandler.java
@@ -16,10 +16,11 @@ import javax.annotation.Nullable;
 public interface DecodedClientMessageHandler {
 
     /**
-     * 处理消息
-     * @param device 设备操作接口,可以为null
-     * @param message
-     * @return
+     * 处理平台收到的设备消息,当设备接入网关接收到设备消息后,将会调用此方法进行处理.
+     *
+     * @param device  设备操作接口,可以为null
+     * @param message Message
+     * @return successful
      */
     Mono<Boolean> handleMessage(@Nullable DeviceOperator device, @Nonnull Message message);
 

--- a/src/main/java/org/jetlinks/supports/server/DefaultClientMessageHandler.java
+++ b/src/main/java/org/jetlinks/supports/server/DefaultClientMessageHandler.java
@@ -8,6 +8,7 @@ import org.jetlinks.core.message.codec.Transport;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+@Deprecated
 @AllArgsConstructor
 public class DefaultClientMessageHandler implements ClientMessageHandler {
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors device message routing to support session selection and return send counts, adds cluster device-session query APIs, and deprecates legacy client message handlers.
> 
> - **Device messaging/routing**:
>   - `RpcDeviceOperationBroker`: adds `send(DeviceMessage)` with session selection (`any/latest/oldest/hashed/minimumLoad/all`), routes to local/remote nodes, and returns delivery count; updates internal handlers to `Function<Message, Mono<Integer>>`; RPC `Service.send` now returns `Mono<Integer>`.
>   - `ClusterSendToDeviceMessageHandler`: returns send counts (`Mono<Integer>`), refines child/multi-gateway handling, async send semantics, and unsupported/failed send replies; propagates reply/sent flags across mutations; adds `mutate(DeviceSession, DeviceMessage)`.
> - **Session management (cluster)**:
>   - `AbstractDeviceSessionManager`: adds `getDeviceSessionInfo(deviceId)` and `remoteDeviceSessions`; local helper for single-device session info.
>   - `ClusterDeviceSessionManager`: RPC adds `deviceSessions(String)`, server/client implementations and `remoteDeviceSessions` bridge.
>   - `LocalDeviceSessionManager`: stubs `remoteDeviceSessions` with empty.
> - **Deprecations**:
>   - Marks `ClientMessageHandler` and `DefaultClientMessageHandler` as deprecated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f000497e5e1acd39ee3252fea301c2eaf7e25123. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->