### PR TITLE
feat: 增加设备身份管理支持

### DIFF
--- a/src/main/java/org/jetlinks/supports/cluster/ClusterDeviceRegistry.java
+++ b/src/main/java/org/jetlinks/supports/cluster/ClusterDeviceRegistry.java
@@ -12,8 +12,8 @@ import org.jetlinks.core.config.ConfigStorageManager;
 import org.jetlinks.core.defaults.DefaultDeviceOperator;
 import org.jetlinks.core.defaults.DefaultDeviceProductOperator;
 import org.jetlinks.core.device.*;
-import org.jetlinks.core.device.identity.Identity;
-import org.jetlinks.core.device.identity.DeviceIdentityManager;
+import org.jetlinks.core.device.DevicePrincipalManager;
+import org.jetlinks.core.principal.Principal;
 import org.jetlinks.core.message.interceptor.DeviceMessageSenderInterceptor;
 import org.jetlinks.core.things.ThingRpcSupportChain;
 import org.jetlinks.supports.config.ClusterConfigStorageManager;
@@ -55,7 +55,7 @@ public class ClusterDeviceRegistry implements DeviceRegistry {
     private ThingRpcSupportChain rpcChain;
 
     @Setter
-    private DeviceIdentityManager identityManager;
+    private DevicePrincipalManager principalManager;
 
     @Deprecated
     public ClusterDeviceRegistry(ProtocolSupports supports,
@@ -194,6 +194,9 @@ public class ClusterDeviceRegistry implements DeviceRegistry {
         DefaultDeviceOperator device = new DefaultDeviceOperator(deviceId, supports, manager, handler, this, interceptor, stateChecker);
         if (rpcChain != null) {
             device.setRpcChain(rpcChain);
+        }
+        if (principalManager != null) {
+            device.setPrincipalManager(principalManager);
         }
         return device;
     }
@@ -335,13 +338,11 @@ public class ClusterDeviceRegistry implements DeviceRegistry {
     }
 
     @Override
-    public Mono<DeviceOperator> getDevice(Identity identity) {
-        if (identityManager != null) {
-            return identityManager
-                .findDevice(identity)
-                .flatMap(this::getDevice);
+    public Mono<DevicePrincipal> resolveDevice(Principal query) {
+        if (principalManager != null) {
+            return principalManager.resolveDevicePrincipal(query);
         }
-        return DeviceRegistry.super.getDevice(identity);
+        return DeviceRegistry.super.resolveDevice(query);
     }
 
     public void addInterceptor(DeviceMessageSenderInterceptor interceptor) {

--- a/src/main/java/org/jetlinks/supports/cluster/ClusterDeviceRegistry.java
+++ b/src/main/java/org/jetlinks/supports/cluster/ClusterDeviceRegistry.java
@@ -12,6 +12,8 @@ import org.jetlinks.core.config.ConfigStorageManager;
 import org.jetlinks.core.defaults.DefaultDeviceOperator;
 import org.jetlinks.core.defaults.DefaultDeviceProductOperator;
 import org.jetlinks.core.device.*;
+import org.jetlinks.core.device.identity.Identity;
+import org.jetlinks.core.device.identity.DeviceIdentityManager;
 import org.jetlinks.core.message.interceptor.DeviceMessageSenderInterceptor;
 import org.jetlinks.core.things.ThingRpcSupportChain;
 import org.jetlinks.supports.config.ClusterConfigStorageManager;
@@ -51,6 +53,9 @@ public class ClusterDeviceRegistry implements DeviceRegistry {
 
     @Setter
     private ThingRpcSupportChain rpcChain;
+
+    @Setter
+    private DeviceIdentityManager identityManager;
 
     @Deprecated
     public ClusterDeviceRegistry(ProtocolSupports supports,
@@ -327,6 +332,16 @@ public class ClusterDeviceRegistry implements DeviceRegistry {
                     .flatMap(ConfigStorage::clear)
             )
             .then();
+    }
+
+    @Override
+    public Mono<DeviceOperator> getDevice(Identity identity) {
+        if (identityManager != null) {
+            return identityManager
+                .findDevice(identity)
+                .flatMap(this::getDevice);
+        }
+        return DeviceRegistry.super.getDevice(identity);
     }
 
     public void addInterceptor(DeviceMessageSenderInterceptor interceptor) {

--- a/src/main/java/org/jetlinks/supports/protocol/blocking/BlockingDevicePrincipal.java
+++ b/src/main/java/org/jetlinks/supports/protocol/blocking/BlockingDevicePrincipal.java
@@ -17,8 +17,8 @@ public class BlockingDevicePrincipal implements DevicePrincipal {
     }
 
     @Override
-    public boolean isAuthorized() {
-        return principal.isAuthorized();
+    public boolean isVerified() {
+        return principal.isVerified();
     }
 
     @Override

--- a/src/main/java/org/jetlinks/supports/protocol/blocking/BlockingDevicePrincipal.java
+++ b/src/main/java/org/jetlinks/supports/protocol/blocking/BlockingDevicePrincipal.java
@@ -1,0 +1,29 @@
+package org.jetlinks.supports.protocol.blocking;
+
+import lombok.AllArgsConstructor;
+import org.jetlinks.core.defaults.BlockingDeviceOperator;
+import org.jetlinks.core.device.DevicePrincipal;
+import org.jetlinks.core.principal.Credential;
+import org.jetlinks.core.principal.Identity;
+
+@AllArgsConstructor
+public class BlockingDevicePrincipal implements DevicePrincipal {
+    private final BlockingDeviceOperator device;
+    private final DevicePrincipal principal;
+
+    @Override
+    public BlockingDeviceOperator getDevice() {
+        return device;
+    }
+
+    @Override
+    public Identity identity() {
+        return principal.identity();
+    }
+
+
+    @Override
+    public Credential credential() {
+        return principal.credential();
+    }
+}

--- a/src/main/java/org/jetlinks/supports/protocol/blocking/BlockingDevicePrincipal.java
+++ b/src/main/java/org/jetlinks/supports/protocol/blocking/BlockingDevicePrincipal.java
@@ -17,6 +17,11 @@ public class BlockingDevicePrincipal implements DevicePrincipal {
     }
 
     @Override
+    public boolean isAuthorized() {
+        return principal.isAuthorized();
+    }
+
+    @Override
     public Identity identity() {
         return principal.identity();
     }

--- a/src/main/java/org/jetlinks/supports/protocol/blocking/BlockingMessageCodecContext.java
+++ b/src/main/java/org/jetlinks/supports/protocol/blocking/BlockingMessageCodecContext.java
@@ -4,10 +4,11 @@ import io.netty.util.concurrent.FastThreadLocalThread;
 import lombok.RequiredArgsConstructor;
 import org.jetlinks.core.defaults.BlockingDeviceOperator;
 import org.jetlinks.core.device.DeviceOperator;
-import org.jetlinks.core.device.identity.Identity;
+import org.jetlinks.core.device.DevicePrincipal;
 import org.jetlinks.core.message.codec.MessageCodecContext;
 import org.jetlinks.core.monitor.Monitor;
 import org.jetlinks.core.monitor.logger.Logger;
+import org.jetlinks.core.principal.Principal;
 import org.jetlinks.core.utils.Reactors;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -60,12 +61,15 @@ class BlockingMessageCodecContext<T extends MessageCodecContext> {
     /**
      * 根据设备身份信息获取设备操作接口
      *
-     * @param identity Identity
      * @return 设备操作接口
      */
     @Nullable
-    public BlockingDeviceOperator getDevice(Identity identity) {
-        return wrapBlocking(await(context.getDevice(identity)));
+    public BlockingDevicePrincipal resolveDevice(Principal principal) {
+        DevicePrincipal devicePrincipal = await(context.resolveDevice(principal));
+        return new BlockingDevicePrincipal(
+            wrapBlocking(devicePrincipal.getDevice()),
+            devicePrincipal
+        );
     }
 
 

--- a/src/main/java/org/jetlinks/supports/protocol/blocking/BlockingMessageCodecContext.java
+++ b/src/main/java/org/jetlinks/supports/protocol/blocking/BlockingMessageCodecContext.java
@@ -66,7 +66,7 @@ class BlockingMessageCodecContext<T extends MessageCodecContext> {
     @Nullable
     public BlockingDevicePrincipal resolveDevice(Principal principal) {
         DevicePrincipal devicePrincipal = await(context.resolveDevice(principal));
-        return new BlockingDevicePrincipal(
+        return devicePrincipal == null ? null : new BlockingDevicePrincipal(
             wrapBlocking(devicePrincipal.getDevice()),
             devicePrincipal
         );

--- a/src/main/java/org/jetlinks/supports/protocol/blocking/BlockingMessageCodecContext.java
+++ b/src/main/java/org/jetlinks/supports/protocol/blocking/BlockingMessageCodecContext.java
@@ -59,7 +59,7 @@ class BlockingMessageCodecContext<T extends MessageCodecContext> {
     }
 
     /**
-     * 根据设备身份信息获取设备操作接口
+     * 根据设备身份信息解析设备操作接口
      *
      * @return 设备操作接口
      */

--- a/src/main/java/org/jetlinks/supports/protocol/blocking/BlockingMessageCodecContext.java
+++ b/src/main/java/org/jetlinks/supports/protocol/blocking/BlockingMessageCodecContext.java
@@ -4,6 +4,7 @@ import io.netty.util.concurrent.FastThreadLocalThread;
 import lombok.RequiredArgsConstructor;
 import org.jetlinks.core.defaults.BlockingDeviceOperator;
 import org.jetlinks.core.device.DeviceOperator;
+import org.jetlinks.core.device.identity.Identity;
 import org.jetlinks.core.message.codec.MessageCodecContext;
 import org.jetlinks.core.monitor.Monitor;
 import org.jetlinks.core.monitor.logger.Logger;
@@ -55,6 +56,18 @@ class BlockingMessageCodecContext<T extends MessageCodecContext> {
     public BlockingDeviceOperator getDevice(String deviceId) {
         return wrapBlocking(await(context.getDevice(deviceId)));
     }
+
+    /**
+     * 根据设备身份信息获取设备操作接口
+     *
+     * @param identity Identity
+     * @return 设备操作接口
+     */
+    @Nullable
+    public BlockingDeviceOperator getDevice(Identity identity) {
+        return wrapBlocking(await(context.getDevice(identity)));
+    }
+
 
     /**
      * 响应式获取指定设备ID的设备操作接口
@@ -201,7 +214,7 @@ class BlockingMessageCodecContext<T extends MessageCodecContext> {
 
             PENDING.set(this, subscriber);
             Thread thread = Thread.currentThread();
-            if (Schedulers.isNonBlockingThread(thread)||
+            if (Schedulers.isNonBlockingThread(thread) ||
                 thread instanceof FastThreadLocalThread) {
                 task.subscribe(subscriber);
             } else {

--- a/src/main/java/org/jetlinks/supports/scalecube/rpc/ScalecubeRpcManager.java
+++ b/src/main/java/org/jetlinks/supports/scalecube/rpc/ScalecubeRpcManager.java
@@ -115,7 +115,7 @@ public class ScalecubeRpcManager implements RpcManager {
                         IOException.class
                     ))
         .scheduler(Schedulers.parallel())
-        .onRetryExhaustedThrow((spec,signal)-> signal.failure())
+        .onRetryExhaustedThrow((spec, signal) -> signal.failure())
         .doBeforeRetry(retrySignal -> {
             if (retrySignal.totalRetriesInARow() > 3) {
                 log.warn("rpc retries {} : [{}]",
@@ -305,7 +305,7 @@ public class ScalecubeRpcManager implements RpcManager {
     @Override
     public Flux<RpcService<?>> getServices() {
         return Flux
-            .fromIterable(serverServiceRef.values())
+            .defer(() -> Flux.fromIterable(serverServiceRef.values()))
             .flatMapIterable(node -> node.serviceInstances.values())
             .flatMapIterable(ServiceInstances::getAllCalls);
     }

--- a/src/main/java/org/jetlinks/supports/server/ClusterSendToDeviceMessageHandler.java
+++ b/src/main/java/org/jetlinks/supports/server/ClusterSendToDeviceMessageHandler.java
@@ -5,6 +5,8 @@ import org.jetlinks.core.device.DeviceConfigKey;
 import org.jetlinks.core.device.DeviceOperationBroker;
 import org.jetlinks.core.device.DeviceOperator;
 import org.jetlinks.core.device.DeviceRegistry;
+import org.jetlinks.core.device.identity.Identity;
+import org.jetlinks.core.device.identity.DeviceIdentityManager;
 import org.jetlinks.core.device.session.DeviceSessionManager;
 import org.jetlinks.core.enums.ErrorCode;
 import org.jetlinks.core.exception.DeviceOperationException;
@@ -42,6 +44,8 @@ public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono
     private final DeviceRegistry registry;
 
     private final DecodedClientMessageHandler decodedClientMessageHandler;
+
+    private DeviceIdentityManager identityManager;
 
     public ClusterSendToDeviceMessageHandler(DeviceSessionManager sessionManager,
                                              MessageHandler handler,
@@ -324,6 +328,11 @@ public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono
         @Override
         public Mono<DeviceOperator> getDevice(String deviceId) {
             return registry.getDevice(deviceId);
+        }
+
+        @Override
+        public Mono<DeviceOperator> getDevice(Identity identity) {
+            return registry.getDevice(identity);
         }
 
         @Override

--- a/src/main/java/org/jetlinks/supports/server/ClusterSendToDeviceMessageHandler.java
+++ b/src/main/java/org/jetlinks/supports/server/ClusterSendToDeviceMessageHandler.java
@@ -1,12 +1,8 @@
 package org.jetlinks.supports.server;
 
 import lombok.extern.slf4j.Slf4j;
-import org.jetlinks.core.device.DeviceConfigKey;
-import org.jetlinks.core.device.DeviceOperationBroker;
-import org.jetlinks.core.device.DeviceOperator;
-import org.jetlinks.core.device.DeviceRegistry;
-import org.jetlinks.core.device.identity.Identity;
-import org.jetlinks.core.device.identity.DeviceIdentityManager;
+import org.jetlinks.core.device.*;
+import org.jetlinks.core.principal.Identity;
 import org.jetlinks.core.device.session.DeviceSessionManager;
 import org.jetlinks.core.enums.ErrorCode;
 import org.jetlinks.core.exception.DeviceOperationException;
@@ -14,6 +10,7 @@ import org.jetlinks.core.message.*;
 import org.jetlinks.core.message.codec.EncodedMessage;
 import org.jetlinks.core.message.codec.ToDeviceMessageContext;
 import org.jetlinks.core.message.state.DeviceStateCheckMessage;
+import org.jetlinks.core.principal.Principal;
 import org.jetlinks.core.server.MessageHandler;
 import org.jetlinks.core.server.session.ChildrenDeviceSession;
 import org.jetlinks.core.server.session.DeviceSession;
@@ -45,7 +42,7 @@ public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono
 
     private final DecodedClientMessageHandler decodedClientMessageHandler;
 
-    private DeviceIdentityManager identityManager;
+    private DevicePrincipalManager identityManager;
 
     public ClusterSendToDeviceMessageHandler(DeviceSessionManager sessionManager,
                                              MessageHandler handler,
@@ -331,8 +328,8 @@ public class ClusterSendToDeviceMessageHandler implements Function<Message, Mono
         }
 
         @Override
-        public Mono<DeviceOperator> getDevice(Identity identity) {
-            return registry.getDevice(identity);
+        public Mono<DevicePrincipal> resolveDevice(Principal principal) {
+            return registry.resolveDevice(principal);
         }
 
         @Override


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new principal-based device resolution paths that can affect authentication/identity mapping behavior, though changes are mostly additive and gated behind an injected `DevicePrincipalManager`.
> 
> **Overview**
> Adds device identity/principal resolution into the cluster registry and messaging/codec layers. `ClusterDeviceRegistry` can now be wired with a `DevicePrincipalManager`, propagates it into created `DefaultDeviceOperator`s, and overrides `resolveDevice(Principal)` to delegate to the manager.
> 
> Extends the blocking protocol API with `BlockingMessageCodecContext.resolveDevice(Principal)` plus a new `BlockingDevicePrincipal` wrapper so blocking codecs can authenticate/lookup devices by principal. `ToDeviceMessageContext` inside `ClusterSendToDeviceMessageHandler` now exposes `resolveDevice` as well.
> 
> Minor reactive correctness/tidy-ups: `ScalecubeRpcManager.getServices()` is now `Flux.defer(...)` (lazy snapshot), plus small formatting-only changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc04493fcea8c410635ad26ab800d61fe5c028d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->