### PR TITLE
fix(集群): 修复ScalecubeRpcManager与ExtendedClusterImpl缺陷

### DIFF
--- a/src/main/java/org/jetlinks/supports/scalecube/ExtendedClusterImpl.java
+++ b/src/main/java/org/jetlinks/supports/scalecube/ExtendedClusterImpl.java
@@ -211,7 +211,7 @@ public class ExtendedClusterImpl implements ExtendedCluster {
         if (TraceHolder.isEnabled()) {
             return TraceHolder
                 .writeContextTo(Message.with(request), Message.Builder::header)
-                .flatMap(msg -> real.requestResponse(address, request));
+                .flatMap(msg -> real.requestResponse(address, msg.build()));
         }
         return real.requestResponse(address, request);
     }
@@ -224,7 +224,7 @@ public class ExtendedClusterImpl implements ExtendedCluster {
         if (TraceHolder.isEnabled()) {
             return TraceHolder
                 .writeContextTo(Message.with(request), Message.Builder::header)
-                .flatMap(msg -> real.requestResponse(member, request));
+                .flatMap(msg -> real.requestResponse(member, msg.build()));
         }
         return real.requestResponse(member, request);
     }
@@ -234,7 +234,7 @@ public class ExtendedClusterImpl implements ExtendedCluster {
         if (TraceHolder.isEnabled()) {
             return TraceHolder
                 .writeContextTo(Message.with(message), Message.Builder::header)
-                .flatMap(msg -> real.spreadGossip(message));
+                .flatMap(msg -> real.spreadGossip(msg.build()));
         }
         return real.spreadGossip(message);
     }
@@ -277,8 +277,13 @@ public class ExtendedClusterImpl implements ExtendedCluster {
     @Override
     public <T> Mono<Void> updateMetadata(T metadata) {
         if (!started) {
-            startThen.add(real.updateMetadata(metadata));
-            return null;
+            Sinks.One<Void> sink = Sinks.one();
+            startThen.add(
+                real.updateMetadata(metadata)
+                    .doOnSuccess(ignore -> sink.emitEmpty(Reactors.emitFailureHandler()))
+                    .doOnError(err -> sink.emitError(err, Reactors.emitFailureHandler()))
+            );
+            return sink.asMono();
         }
         return real.updateMetadata(metadata);
     }

--- a/src/main/java/org/jetlinks/supports/scalecube/rpc/ScalecubeRpcManager.java
+++ b/src/main/java/org/jetlinks/supports/scalecube/rpc/ScalecubeRpcManager.java
@@ -3,7 +3,6 @@ package org.jetlinks.supports.scalecube.rpc;
 import com.fasterxml.jackson.core.JacksonException;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.ThreadLocalRandom;
 import io.rsocket.exceptions.Retryable;
 import io.scalecube.cluster.ClusterMessageHandler;
 import io.scalecube.cluster.Member;
@@ -61,6 +60,7 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.*;
@@ -395,7 +395,7 @@ public class ScalecubeRpcManager implements RpcManager {
         }
     }
 
-    private ServiceEndpoint createEndpoint() {
+    ServiceEndpoint createEndpoint() {
         return ServiceEndpoint
             .builder()
             .id(id)
@@ -594,16 +594,21 @@ public class ScalecubeRpcManager implements RpcManager {
         return selector.finisher().apply(container);
     }
 
+    private <I> RpcService<I> selectRandomService0(Class<I> service) {
+        RandomServiceSelector<RpcService<I>> selector = new RandomServiceSelector<>();
+        for (Map.Entry<String, ClusterNode> entry : serverServiceRef.entrySet()) {
+            entry
+                .getValue()
+                .getApiCalls(null, service, selector, (random, rpcService) -> random.onNext(rpcService));
+        }
+        return selector.selected;
+    }
+
 
     @Override
     public <I> Mono<RpcService<I>> selectService(Class<I> service, Object routeKey) {
         if (routeKey == null) {
-            return Mono
-                .fromSupplier(() -> this
-                    .selectService0(
-                        service,
-                        Collectors.minBy(Comparator.comparingLong(s -> ThreadLocalRandom.current().nextInt())))
-                    .orElse(null));
+            return Mono.fromSupplier(() -> this.selectRandomService0(service));
         }
         return Mono
             .fromSupplier(() -> this
@@ -661,10 +666,18 @@ public class ScalecubeRpcManager implements RpcManager {
         return retry;
     }
 
-    private void memberLeave(Member member) {
+    void memberLeave(Member member) {
         String id = member.alias() == null ? member.id() : member.alias();
-        ClusterNode ref = serverServiceRef.remove(id);
-        if (null != ref) {
+        ClusterNode ref = serverServiceRef.get(id);
+        if (ref == null) {
+            return;
+        }
+        Member currentMember = ref.member;
+        if (currentMember != null && !Objects.equals(currentMember.id(), member.id())) {
+            log.debug("ignore stale service endpoint removal [{}], current member is [{}]", member, currentMember);
+            return;
+        }
+        if (serverServiceRef.remove(id, ref)) {
             fireEvent(ref.services.values(), id, ServiceEvent.Type.removed);
             ref.dispose();
         }
@@ -682,13 +695,30 @@ public class ScalecubeRpcManager implements RpcManager {
         }
     }
 
-    private void handleServiceEndpoint(Member member, ServiceEndpoint endpoint) {
+    void handleServiceEndpoint(Member member, ServiceEndpoint endpoint) {
         if (cluster.member().id().equals(member.id())) {
             return;
         }
         String id = member.alias() == null ? member.id() : member.alias();
 
-        ClusterNode references = serverServiceRef.computeIfAbsent(id, ignore -> new ClusterNode());
+        ClusterNode references = serverServiceRef.get(id);
+        if (references != null) {
+            Member currentMember = references.member;
+            if (currentMember != null && !Objects.equals(currentMember.id(), member.id())) {
+                ClusterNode replaced = new ClusterNode();
+                replaced.id = id;
+                serverServiceRef.put(id, replaced);
+                fireEvent(references.services.values(), id, ServiceEvent.Type.removed);
+                references.dispose();
+                references = replaced;
+            }
+        }
+        if (references == null) {
+            ClusterNode created = new ClusterNode();
+            created.id = id;
+            ClusterNode previous = serverServiceRef.putIfAbsent(id, created);
+            references = previous == null ? created : previous;
+        }
         references.id = id;
         references.member = member;
         references.rpcAddress = endpoint.address();
@@ -767,6 +797,7 @@ public class ScalecubeRpcManager implements RpcManager {
                 if (removed.remove(registration.namespace()) == null) {
                     added.put(registration.namespace(), registration);
                 }
+                services.put(registration.namespace(), registration);
 
                 for (ServiceMethodDefinition method : registration.methods()) {
                     ServiceReference ref = new ServiceReference(method, registration, endpoint);
@@ -784,7 +815,6 @@ public class ScalecubeRpcManager implements RpcManager {
             }
 
             removed.forEach((k, v) -> services.remove(k));
-            services.putAll(added);
 
             fireEvent(added.values(), id, ServiceEvent.Type.added);
             fireEvent(removed.values(), id, ServiceEvent.Type.removed);
@@ -796,9 +826,11 @@ public class ScalecubeRpcManager implements RpcManager {
                 .tags()
                 .getOrDefault(SERVICE_ID_TAG, DEFAULT_SERVICE_ID);
 
-            return serviceReferencesByQualifier
-                .computeIfAbsent(qualifier, key -> new NonBlockingHashSet<>())
-                .add(new ServiceReferenceInfo(id, serviceReference));
+            Set<ServiceReferenceInfo> references = serviceReferencesByQualifier
+                .computeIfAbsent(qualifier, key -> new NonBlockingHashSet<>());
+            references.remove(new ServiceReferenceInfo(id, null));
+            references.add(new ServiceReferenceInfo(id, serviceReference));
+            return true;
         }
 
         private <I> RpcServiceCall<I> createApiCall(String serviceId, Class<I> clazz) {
@@ -1201,6 +1233,17 @@ public class ScalecubeRpcManager implements RpcManager {
         @Override
         public String toString() {
             return name + "@" + serverNodeId;
+        }
+    }
+
+    static class RandomServiceSelector<T> {
+        private long size;
+        private T selected;
+
+        private void onNext(T candidate) {
+            if (ThreadLocalRandom.current().nextLong(++size) == 0) {
+                selected = candidate;
+            }
         }
     }
 

--- a/src/test/java/org/jetlinks/supports/scalecube/ExtendedClusterImplTest.java
+++ b/src/test/java/org/jetlinks/supports/scalecube/ExtendedClusterImplTest.java
@@ -1,15 +1,113 @@
 package org.jetlinks.supports.scalecube;
 
-
-import io.scalecube.cluster.ClusterConfig;
-import io.scalecube.transport.netty.tcp.TcpTransportFactory;
-import lombok.SneakyThrows;
+import io.opentelemetry.api.OpenTelemetry;
+import io.scalecube.cluster.ClusterImpl;
+import io.scalecube.cluster.Member;
+import io.scalecube.cluster.transport.api.Message;
+import io.scalecube.net.Address;
+import org.jetlinks.core.trace.TraceHolder;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
-import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ExtendedClusterImplTest {
 
+    @Test
+    public void shouldUseDecoratedMessageForRequestResponseByAddressWhenTraceEnabled() {
+        TraceHolder.setup(OpenTelemetry.noop());
 
+        ClusterImpl real = mockClusterImpl();
+        Address address = Address.create("127.0.0.1", 18080);
+        Message request = Message.withData("test").qualifier("/test").build();
+
+        when(real.member(address)).thenReturn(Optional.of(mock(Member.class)));
+        when(real.requestResponse(eq(address), any(Message.class))).thenReturn(Mono.just(request));
+
+        ExtendedClusterImpl cluster = new ExtendedClusterImpl(real);
+
+        cluster.requestResponse(address, request).block();
+
+        ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+        verify(real).requestResponse(eq(address), captor.capture());
+        Assert.assertNotSame(request, captor.getValue());
+    }
+
+    @Test
+    public void shouldUseDecoratedMessageForRequestResponseByMemberWhenTraceEnabled() {
+        TraceHolder.setup(OpenTelemetry.noop());
+
+        ClusterImpl real = mockClusterImpl();
+        Member member = mock(Member.class);
+        Address address = Address.create("127.0.0.1", 18081);
+        Message request = Message.withData("test").qualifier("/test").build();
+
+        when(member.address()).thenReturn(address);
+        when(real.member(address)).thenReturn(Optional.of(member));
+        when(real.requestResponse(eq(member), any(Message.class))).thenReturn(Mono.just(request));
+
+        ExtendedClusterImpl cluster = new ExtendedClusterImpl(real);
+
+        cluster.requestResponse(member, request).block();
+
+        ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+        verify(real).requestResponse(eq(member), captor.capture());
+        Assert.assertNotSame(request, captor.getValue());
+    }
+
+    @Test
+    public void shouldUseDecoratedMessageForSpreadGossipWhenTraceEnabled() {
+        TraceHolder.setup(OpenTelemetry.noop());
+
+        ClusterImpl real = mockClusterImpl();
+        Message message = Message.withData("test").qualifier("/test").build();
+
+        when(real.spreadGossip(any(Message.class))).thenReturn(Mono.just("ok"));
+
+        ExtendedClusterImpl cluster = new ExtendedClusterImpl(real);
+
+        cluster.spreadGossip(message).block();
+
+        ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+        verify(real).spreadGossip(captor.capture());
+        Assert.assertNotSame(message, captor.getValue());
+    }
+
+    @Test
+    public void shouldDeferUpdateMetadataUntilStartAndReturnCompletableMono() {
+        ClusterImpl real = mockClusterImpl();
+        AtomicInteger updateCalls = new AtomicInteger();
+
+        when(real.start()).thenReturn(Mono.just(real));
+        when(real.updateMetadata("metadata"))
+            .thenReturn(Mono.fromRunnable(updateCalls::incrementAndGet));
+
+        ExtendedClusterImpl cluster = new ExtendedClusterImpl(real);
+
+        Mono<Void> pending = cluster.updateMetadata("metadata");
+
+        Assert.assertNotNull(pending);
+        Assert.assertEquals(0, updateCalls.get());
+
+        cluster.start().block();
+
+        StepVerifier.create(pending).verifyComplete();
+        Assert.assertEquals(1, updateCalls.get());
+    }
+
+    private ClusterImpl mockClusterImpl() {
+        ClusterImpl real = mock(ClusterImpl.class);
+        when(real.handler(any())).thenReturn(real);
+        return real;
+    }
 }

--- a/src/test/java/org/jetlinks/supports/scalecube/rpc/ScalecubeRpcManagerTest.java
+++ b/src/test/java/org/jetlinks/supports/scalecube/rpc/ScalecubeRpcManagerTest.java
@@ -26,12 +26,12 @@ import reactor.tools.agent.ReactorDebugAgent;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Comparator;
 import java.util.Locale;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 public class ScalecubeRpcManagerTest {
+    ExtendedCluster cluster1, cluster2, cluster3;
     Member node1, node2, node3;
     ScalecubeRpcManager manager1, manager2, manager3;
 
@@ -63,54 +63,58 @@ public class ScalecubeRpcManagerTest {
 
     }
 
+    private ExtendedCluster startCluster(String alias, ExtendedCluster seed) {
+        ClusterConfig config = ClusterConfig
+            .defaultConfig()
+            .transport(conf -> conf.transportFactory(new TcpTransportFactory()))
+            .memberAlias(alias);
+        if (seed != null) {
+            config = config.membership(conf -> conf.seedMembers(seed.address()));
+        }
+        return new ExtendedClusterImpl(config).startAwait();
+    }
+
+    private ScalecubeRpcManager startManager(ExtendedCluster cluster) {
+        ScalecubeRpcManager manager = new ScalecubeRpcManager(cluster, RSocketServiceTransport::new);
+        manager.startAwait();
+        return manager;
+    }
+
     @Before
     public void init() {
-        ExtendedCluster cluster = new ExtendedClusterImpl(
-            ClusterConfig
-                .defaultConfig()
-                .memberAlias("node1")
-                .transport(conf -> conf.transportFactory(new TcpTransportFactory()))
-        ).startAwait();
-        node1 = cluster.member();
+        cluster1 = startCluster("node1", null);
+        node1 = cluster1.member();
+        manager1 = startManager(cluster1);
 
-        {
-            manager1 = new ScalecubeRpcManager(cluster, RSocketServiceTransport::new);
-            manager1.startAwait();
+        cluster2 = startCluster("node2", cluster1);
+        node2 = cluster2.member();
+        manager2 = startManager(cluster2);
 
-        }
-
-        {
-            ExtendedCluster cluster2 = new ExtendedClusterImpl(
-                ClusterConfig
-                    .defaultConfig()
-                    .transport(conf -> conf.transportFactory(new TcpTransportFactory()))
-                    .memberAlias("node2")
-                    .membership(conf -> conf.seedMembers(cluster.address()))
-            ).startAwait();
-            manager2 = new ScalecubeRpcManager(cluster2, RSocketServiceTransport::new);
-            manager2.startAwait();
-            node2 = cluster2.member();
-        }
-
-        {
-            ExtendedCluster cluster3 = new ExtendedClusterImpl(
-                ClusterConfig
-                    .defaultConfig()
-                    .transport(conf -> conf.transportFactory(new TcpTransportFactory()))
-                    .membership(conf -> conf.seedMembers(cluster.address()))
-                    .memberAlias("node3")
-            ).startAwait();
-            node3 = cluster3.member();
-            manager3 = new ScalecubeRpcManager(cluster3, RSocketServiceTransport::new);
-            manager3.startAwait();
-        }
+        cluster3 = startCluster("node3", cluster1);
+        node3 = cluster3.member();
+        manager3 = startManager(cluster3);
     }
 
     @After
     public void shutdown() {
-        manager3.stopAwait();
-        manager2.stopAwait();
-        manager1.stopAwait();
+        if (manager3 != null) {
+            manager3.stopAwait();
+        }
+        if (manager2 != null) {
+            manager2.stopAwait();
+        }
+        if (manager1 != null) {
+            manager1.stopAwait();
+        }
+        if (cluster3 != null && !cluster3.isShutdown()) {
+            cluster3.shutdown();
+        }
+        if (cluster2 != null && !cluster2.isShutdown()) {
+            cluster2.shutdown();
+        }
+        if (cluster1 != null && !cluster1.isShutdown()) {
+            cluster1.shutdown();
+        }
     }
 
     @Test
@@ -313,6 +317,95 @@ public class ScalecubeRpcManagerTest {
             .as(StepVerifier::create)
             .expectNext("1TEST-1")
             .verifyComplete();
+    }
+
+    @Test
+    @SneakyThrows
+    public void testSelectServiceWithoutRouteKey() {
+        manager1.registerService("s1", new ServiceImpl("1"));
+        manager2.registerService("s1", new ServiceImpl("2"));
+
+        Thread.sleep(2000);
+
+        manager3.selectService(Service.class)
+                .flatMap(service -> service.service().upper("test"))
+                .as(StepVerifier::create)
+                .expectNextMatches(result -> "1TEST".equals(result) || "2TEST".equals(result))
+                .verifyComplete();
+    }
+
+    @Test
+    @SneakyThrows
+    public void testNodeRestartShouldRecoverRouteWithoutGatewayRestart() {
+        manager2.registerService("s1", new ServiceImpl("2"));
+
+        Thread.sleep(2000);
+
+        manager3.getService(node2.alias(), "s1", Service.class)
+                .flatMap(service -> service.upper("test"))
+                .as(StepVerifier::create)
+                .expectNext("2TEST")
+                .verifyComplete();
+
+        manager2.stopAwait();
+        cluster2.shutdown();
+
+        Thread.sleep(2000);
+
+        manager3.getService(node2.alias(), "s1", Service.class)
+                .as(StepVerifier::create)
+                .verifyComplete();
+
+        cluster2 = startCluster("node2", cluster1);
+        node2 = cluster2.member();
+        manager2 = startManager(cluster2);
+        manager2.registerService("s1", new ServiceImpl("2-1"));
+
+        Thread.sleep(2000);
+
+        manager3.getService(node2.alias(), "s1", Service.class)
+                .flatMap(service -> service.upper("test"))
+                .as(StepVerifier::create)
+                .expectNext("2-1TEST")
+                .verifyComplete();
+    }
+
+    @Test
+    @SneakyThrows
+    public void testAliasReuseShouldRefreshServiceReferenceAndIgnoreStaleLeave() {
+        manager2.registerService("s1", new ServiceImpl("old"));
+
+        Thread.sleep(2000);
+
+        manager3.getService(node2.alias(), "s1", Service.class)
+                .flatMap(service -> service.upper("test"))
+                .as(StepVerifier::create)
+                .expectNext("oldTEST")
+                .verifyComplete();
+
+        ExtendedCluster replacementCluster = startCluster("node2", null);
+        ScalecubeRpcManager replacementManager = startManager(replacementCluster);
+        try {
+            replacementManager.registerService("s1", new ServiceImpl("new"));
+            manager3.handleServiceEndpoint(replacementCluster.member(), replacementManager.createEndpoint());
+
+            manager3.getService(node2.alias(), "s1", Service.class)
+                    .flatMap(service -> service.upper("test"))
+                    .as(StepVerifier::create)
+                    .expectNext("newTEST")
+                    .verifyComplete();
+
+            manager3.memberLeave(node2);
+
+            manager3.getService(node2.alias(), "s1", Service.class)
+                    .flatMap(service -> service.upper("test"))
+                    .as(StepVerifier::create)
+                    .expectNext("newTEST")
+                    .verifyComplete();
+        } finally {
+            replacementManager.stopAwait();
+            replacementCluster.shutdown();
+        }
     }
 
     /**


### PR DESCRIPTION
## 背景
- `routeKey == null` 时当前实现通过随机 comparator 走 `Collectors.minBy(...)`，违反 comparator 契约，且选路概率会偏向后序候选。
- 节点重启且复用同一 alias 时，旧节点的 `ServiceReference` 和迟到的 `memberLeave` 事件可能覆盖新节点路由，导致网关路由不及时刷新。
- `ExtendedClusterImpl` 的 trace 透传路径在构造新 `Message` 后仍发送旧对象，导致 trace header 丢失。
- `ExtendedClusterImpl.updateMetadata()` 在集群未启动前返回 `null`，调用方无法正确等待延迟执行结果。
- `jetlinks-components` 中与 lifecycle / discovery / gateway route 相关的问题已单独放在 [`jetlinks-components#1467`](https://github.com/jetlinks-v2/jetlinks-components/pull/1467) 跟进；本 PR 只处理 `jetlinks-supports` 应负责的底层 RPC / cluster 修复。

## 本 PR 任务清单

### A. ScalecubeRpcManager
- [x] 将无 `routeKey` 的选路改为单遍、O(1) 内存的蓄水池抽样，移除随机 comparator
- [x] 在 alias 复用且 `memberId` 变化时替换 `ClusterNode`，避免旧节点内部状态残留
- [x] 刷新相同 `serviceId` 的 `ServiceReference`，确保节点重连后路由地址及时更新
- [x] 忽略已过期的 `memberLeave` 事件，避免新节点接管后又被旧下线事件清空路由

### B. ExtendedClusterImpl
- [x] 修复 `requestResponse(Address, Message)` trace 头写入后仍发送旧 message 的问题
- [x] 修复 `requestResponse(Member, Message)` trace 头写入后仍发送旧 message 的问题
- [x] 修复 `spreadGossip(Message)` trace 头写入后仍发送旧 message 的问题
- [x] 修复 `updateMetadata()` 在未启动前返回 `null` 的问题，改为返回可完成的 `Mono<Void>`

### C. 已补测试
- [x] 补充 `routeKey` 为空测试
- [x] 补充节点重启恢复测试
- [x] 补充 alias 复用与迟到下线事件测试
- [x] 补充 trace 透传测试
- [x] 补充 pre-start metadata 更新测试

## 明确不在本 PR 的范围

以下事项已明确延后，不在本 PR 内处理：

- `RpcManager.getServices()` / `ScalecubeRpcManager.getServices()` 是否包含 self 的语义调整
- local / remote service 语义拆分
- `ExtendedClusterImpl` feature API 清理或重构

## 验证
- [x] `mvn -o -Dmaven.repo.local=/tmp/m2-repo-jetlinks -Dtest=ScalecubeRpcManagerTest#testSelectServiceWithoutRouteKey+testNodeRestartShouldRecoverRouteWithoutGatewayRestart+testAliasReuseShouldRefreshServiceReferenceAndIgnoreStaleLeave test`
- [x] `mvn -o -Dmaven.repo.local=/tmp/m2-repo-jetlinks -Dtest=ExtendedClusterImplTest test`
- [x] `mvn -o -Dmaven.repo.local=/tmp/m2-repo-jetlinks -Dtest=ScalecubeTest,ScalecubeRpcManagerTest,ClusterDeviceSessionManagerTest,ExtendedClusterImplTest test`

### 验证结果
- `ExtendedClusterImplTest`: 4 passed, 0 failed, 0 errors, 0 skipped
- `ScalecubeTest + ScalecubeRpcManagerTest + ClusterDeviceSessionManagerTest + ExtendedClusterImplTest`: 25 passed, 0 failed, 0 errors, 0 skipped

## 说明
- 本次仅调整 `ScalecubeRpcManager` / `ExtendedClusterImpl` 内部服务发现、选路与消息透传逻辑，无额外对外接口变更。
- `ClusterLifecycle` / discovery self-register / gateway route cache 等下游集成问题见 [`jetlinks-components#1467`](https://github.com/jetlinks-v2/jetlinks-components/pull/1467)。
