### PR TITLE
feat(metadata): 支持物模型modules解析与设备模块Provider注册

### DIFF
--- a/src/main/java/org/jetlinks/supports/cluster/ClusterDeviceRegistry.java
+++ b/src/main/java/org/jetlinks/supports/cluster/ClusterDeviceRegistry.java
@@ -57,6 +57,9 @@ public class ClusterDeviceRegistry implements DeviceRegistry {
     @Setter
     private DevicePrincipalManager principalManager;
 
+    @Setter
+    private DeviceModuleThingProvider moduleThingProvider;
+
     @Deprecated
     public ClusterDeviceRegistry(ProtocolSupports supports,
                                  ClusterManager clusterManager,
@@ -197,6 +200,9 @@ public class ClusterDeviceRegistry implements DeviceRegistry {
         }
         if (principalManager != null) {
             device.setPrincipalManager(principalManager);
+        }
+        if (moduleThingProvider != null) {
+            device.setModuleThingProvider(moduleThingProvider);
         }
         return device;
     }
@@ -358,6 +364,17 @@ public class ClusterDeviceRegistry implements DeviceRegistry {
             this.rpcChain = chain;
         } else {
             this.rpcChain = this.rpcChain.composite(Collections.singleton(chain));
+        }
+    }
+
+    public void addModuleThingProvider(DeviceModuleThingProvider provider) {
+        if (this.moduleThingProvider == null) {
+            this.moduleThingProvider = provider;
+        } else {
+            DeviceModuleThingProvider old = this.moduleThingProvider;
+            this.moduleThingProvider = (device, moduleCode) -> old
+                .getModuleThing(device, moduleCode)
+                .switchIfEmpty(provider.getModuleThing(device, moduleCode));
         }
     }
 }

--- a/src/main/java/org/jetlinks/supports/official/DefaultThingsMetadata.java
+++ b/src/main/java/org/jetlinks/supports/official/DefaultThingsMetadata.java
@@ -29,7 +29,11 @@ public class DefaultThingsMetadata implements ThingMetadata {
 
     private volatile Map<String, PropertyMetadata> tags;
 
+    private volatile Map<String, ThingMetadata> modules;
+
     private volatile List<PropertyMetadata> propertyMetadataList;
+
+    private volatile List<ThingMetadata> moduleMetadataList;
 
     @Getter
     @Setter
@@ -52,7 +56,7 @@ public class DefaultThingsMetadata implements ThingMetadata {
     }
 
     public DefaultThingsMetadata(JSONObject jsonObject) {
-        this.jsonObject = jsonObject;
+        fromJson(jsonObject);
     }
 
     public DefaultThingsMetadata(ThingMetadata another) {
@@ -83,6 +87,12 @@ public class DefaultThingsMetadata implements ThingMetadata {
             .stream()
             .map(JetLinksPropertyMetadata::new)
             .collect(Collectors.toMap(JetLinksPropertyMetadata::getId, Function.identity(), (a, b) -> a, LinkedHashMap::new));
+
+        this.modules = another
+            .getModules()
+            .stream()
+            .map(DefaultThingsMetadata::new)
+            .collect(Collectors.toMap(DefaultThingsMetadata::getId, Function.identity(), (a, b) -> a, LinkedHashMap::new));
 
     }
 
@@ -183,6 +193,33 @@ public class DefaultThingsMetadata implements ThingMetadata {
     }
 
     @Override
+    public List<ThingMetadata> getModules() {
+        if (CollectionUtils.isNotEmpty(this.moduleMetadataList)) {
+            return this.moduleMetadataList;
+        }
+        if (this.modules == null && jsonObject != null) {
+            this.modules = Optional
+                .ofNullable(jsonObject.getJSONArray("modules"))
+                .map(Collection::stream)
+                .<Map<String, ThingMetadata>>map(stream -> stream
+                    .map(obj -> new DefaultThingsMetadata(toJSONObject(obj)))
+                    .collect(Collectors.toMap(
+                        ThingMetadata::getId,
+                        Function.identity(),
+                        (a, b) -> a,
+                        LinkedHashMap::new))
+                )
+                .orElse(Collections.emptyMap());
+        }
+
+        if (this.moduleMetadataList == null && this.modules != null) {
+            this.moduleMetadataList = Collections.unmodifiableList(new ArrayList<>(this.modules.values()));
+            return this.moduleMetadataList;
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
     public EventMetadata getEventOrNull(String id) {
         if (events == null) {
             getEvents();
@@ -253,6 +290,14 @@ public class DefaultThingsMetadata implements ThingMetadata {
         this.tags.put(metadata.getId(), new JetLinksPropertyMetadata(metadata));
     }
 
+    public void addModule(ThingMetadata metadata) {
+        if (this.modules == null) {
+            this.modules = new LinkedHashMap<>();
+        }
+        this.modules.put(metadata.getId(), new DefaultThingsMetadata(metadata));
+        this.moduleMetadataList = Collections.unmodifiableList(new ArrayList<>(this.modules.values()));
+    }
+
     public Map<String, Object> getExpands() {
         if (this.expands == null && jsonObject != null) {
             this.expands = jsonObject.getJSONObject("expands");
@@ -270,6 +315,7 @@ public class DefaultThingsMetadata implements ThingMetadata {
         json.put("functions", getFunctions().stream().map(Jsonable::toJson).collect(Collectors.toList()));
         json.put("events", getEvents().stream().map(Jsonable::toJson).collect(Collectors.toList()));
         json.put("tags", getTags().stream().map(Jsonable::toJson).collect(Collectors.toList()));
+        json.put("modules", getModules().stream().map(Jsonable::toJson).collect(Collectors.toList()));
         json.put("expands", expands);
         return json;
     }
@@ -281,6 +327,9 @@ public class DefaultThingsMetadata implements ThingMetadata {
         this.events = null;
         this.functions = null;
         this.tags = null;
+        this.modules = null;
+        this.propertyMetadataList = null;
+        this.moduleMetadataList = null;
         this.id = json.getString("id");
         this.name = json.getString("name");
         this.description = json.getString("description");
@@ -343,6 +392,14 @@ public class DefaultThingsMetadata implements ThingMetadata {
         for (PropertyMetadata tag : metadata.getTags()) {
             doMerge(deviceMetadata.tags, tag, PropertyMetadata::merge, options);
         }
+
+        if (deviceMetadata.modules == null) {
+            deviceMetadata.getModules();
+        }
+        for (ThingMetadata module : metadata.getModules()) {
+            doMerge(deviceMetadata.modules, new DefaultThingsMetadata(module), ThingMetadata::merge, options);
+        }
+        deviceMetadata.moduleMetadataList = null;
 
         return deviceMetadata;
     }

--- a/src/test/java/org/jetlinks/supports/official/DefaultThingsMetadataModulesTest.java
+++ b/src/test/java/org/jetlinks/supports/official/DefaultThingsMetadataModulesTest.java
@@ -1,0 +1,54 @@
+package org.jetlinks.supports.official;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import org.jetlinks.core.things.ThingMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DefaultThingsMetadataModulesTest {
+
+    @Test
+    public void testDecodeAndEncodeModules() {
+        JSONObject json = JSON.parseObject("{\n" +
+            "  \"id\": \"device\",\n" +
+            "  \"name\": \"设备\",\n" +
+            "  \"properties\": [],\n" +
+            "  \"functions\": [],\n" +
+            "  \"events\": [],\n" +
+            "  \"tags\": [],\n" +
+            "  \"modules\": [{\n" +
+            "    \"id\": \"temperature-board\",\n" +
+            "    \"name\": \"温控板\",\n" +
+            "    \"properties\": [],\n" +
+            "    \"functions\": [],\n" +
+            "    \"events\": [],\n" +
+            "    \"tags\": []\n" +
+            "  }]\n" +
+            "}");
+
+        DefaultThingsMetadata metadata = new DefaultThingsMetadata(json);
+
+        Assert.assertEquals(1, metadata.getModules().size());
+        ThingMetadata module = metadata.getModule("temperature-board").orElse(null);
+        Assert.assertNotNull(module);
+        Assert.assertEquals("温控板", module.getName());
+
+        JSONObject encoded = metadata.toJson();
+        Assert.assertTrue(encoded.containsKey("modules"));
+        Assert.assertEquals(1, encoded.getJSONArray("modules").size());
+        Assert.assertEquals("temperature-board", encoded.getJSONArray("modules").getJSONObject(0).getString("id"));
+    }
+
+    @Test
+    public void testCopyKeepsModules() {
+        DefaultThingsMetadata metadata = new DefaultThingsMetadata("device", "设备");
+        metadata.addModule(new DefaultThingsMetadata("module-a", "模块A"));
+
+        DefaultThingsMetadata copied = new DefaultThingsMetadata(metadata);
+
+        Assert.assertEquals(1, copied.getModules().size());
+        Assert.assertNotNull(copied.getModuleOrNull("module-a"));
+        Assert.assertEquals(1, copied.toJson().getJSONArray("modules").size());
+    }
+}


### PR DESCRIPTION
## 变更目的

为设备增加“模块”能力：模块归属于父设备，不作为子设备或独立物类型；支持模块编码、模块 Thing、模块级物模型、模块属性/事件存储查询，以及标准/官方协议模块 Topic。

## 设计边界

- 设备模块不是子设备，不参与独立认证、会话、在线、固件、子设备拓扑或独立权限。
- 模块物模型只继承父设备/产品 metadata 中 `modules[moduleCode]` 对应模块物模型。
- 模块操作走 `ThingModuleMessage` / `DeviceModuleMessage`。
- 模块属性/事件使用独立 row-shaped 表；column mode 下也回退到模块 row-shaped 表。
- 模块日志不单独建表，复用父设备日志。
- 事件值内部字段搜索 / JSONB 深度索引不是本次交付范围。
- 未改造协议包不自动支持模块消息。

## 验证

已在 detached clean worktrees 中仅应用设备模块 patch 并执行 PR 包级门禁：

```bash
bash .ai/device-module-release/run-pr-package-gates.sh
```

结果：

```text
OK: device module PR package gates passed on detached clean worktrees.
SUMMARY audit_mode=worktree-diff actual_diff_files=68 extra_files=0
OK: all diff files are within device module release file list.
```

覆盖：core/supports、device-manager、things-component、timescaledb Testcontainers、标准协议、官方协议、manifest、patch apply、自检与 diff 边界审计。

## 关联 PR

该能力为多仓库联动发布，请按依赖顺序合并：

1. jetlinks-core
2. jetlinks-supports
3. jetlinks-components
4. device-manager
5. jetlinks-protocols
6. jetlinks-official-protocol
7. jetlinks-ultimate 发布材料
