### PR TITLE
feat(metadata): 支持物模型modules解析与设备模块Provider注册

### DIFF
--- a/src/main/java/org/jetlinks/supports/cluster/ClusterDeviceRegistry.java
+++ b/src/main/java/org/jetlinks/supports/cluster/ClusterDeviceRegistry.java
@@ -16,6 +16,7 @@ import org.jetlinks.core.device.DevicePrincipalManager;
 import org.jetlinks.core.principal.Principal;
 import org.jetlinks.core.message.interceptor.DeviceMessageSenderInterceptor;
 import org.jetlinks.core.things.ThingRpcSupportChain;
+import org.jetlinks.supports.device.DefaultDeviceModuleThingProvider;
 import org.jetlinks.supports.config.ClusterConfigStorageManager;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
@@ -57,6 +58,11 @@ public class ClusterDeviceRegistry implements DeviceRegistry {
     @Setter
     private DevicePrincipalManager principalManager;
 
+    @Setter
+    private DeviceModuleThingProvider moduleThingProvider;
+
+    private final DeviceModuleThingProvider defaultModuleThingProvider;
+
     @Deprecated
     public ClusterDeviceRegistry(ProtocolSupports supports,
                                  ClusterManager clusterManager,
@@ -78,6 +84,7 @@ public class ClusterDeviceRegistry implements DeviceRegistry {
         this.manager = storageManager;
         this.operatorCache = cache;
         this.clusterManager = clusterManager;
+        this.defaultModuleThingProvider = new DefaultDeviceModuleThingProvider(storageManager);
         this.addStateChecker(DefaultDeviceOperator.DEFAULT_STATE_CHECKER);
     }
 
@@ -91,6 +98,7 @@ public class ClusterDeviceRegistry implements DeviceRegistry {
         this.manager = new ClusterConfigStorageManager(clusterManager);
         this.operatorCache = cache;
         this.clusterManager = clusterManager;
+        this.defaultModuleThingProvider = new DefaultDeviceModuleThingProvider(this.manager);
         this.addStateChecker(DefaultDeviceOperator.DEFAULT_STATE_CHECKER);
     }
 
@@ -198,6 +206,7 @@ public class ClusterDeviceRegistry implements DeviceRegistry {
         if (principalManager != null) {
             device.setPrincipalManager(principalManager);
         }
+        device.setModuleThingProvider(moduleThingProvider == null ? defaultModuleThingProvider : moduleThingProvider);
         return device;
     }
 
@@ -358,6 +367,17 @@ public class ClusterDeviceRegistry implements DeviceRegistry {
             this.rpcChain = chain;
         } else {
             this.rpcChain = this.rpcChain.composite(Collections.singleton(chain));
+        }
+    }
+
+    public void addModuleThingProvider(DeviceModuleThingProvider provider) {
+        if (this.moduleThingProvider == null) {
+            this.moduleThingProvider = provider;
+        } else {
+            DeviceModuleThingProvider old = this.moduleThingProvider;
+            this.moduleThingProvider = (device, code) -> old
+                .getModuleThings(device, code)
+                .switchIfEmpty(provider.getModuleThings(device, code));
         }
     }
 }

--- a/src/main/java/org/jetlinks/supports/device/DefaultDeviceModule.java
+++ b/src/main/java/org/jetlinks/supports/device/DefaultDeviceModule.java
@@ -1,0 +1,340 @@
+package org.jetlinks.supports.device;
+
+import com.alibaba.fastjson.JSONObject;
+import org.jetlinks.core.Value;
+import org.jetlinks.core.Values;
+import org.jetlinks.core.config.ConfigKeyValue;
+import org.jetlinks.core.config.ConfigStorage;
+import org.jetlinks.core.device.DeviceModule;
+import org.jetlinks.core.device.DeviceOperator;
+import org.jetlinks.core.message.DeviceMessage;
+import org.jetlinks.core.message.Headers;
+import org.jetlinks.core.message.Message;
+import org.jetlinks.core.message.ThingMessage;
+import org.jetlinks.core.message.module.DeviceModuleMessage;
+import org.jetlinks.core.things.ThingMetadata;
+import org.jetlinks.core.things.ThingTemplate;
+import org.jetlinks.core.things.ThingType;
+import org.jetlinks.supports.official.DefaultThingsMetadata;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 基于设备注册中心配置缓存的通用设备模块实现.
+ *
+ * @author zhouhao
+ * @since 1.3.2
+ */
+public class DefaultDeviceModule implements DeviceModule {
+
+    public static final ThingType TYPE = ThingType.of("device-module");
+
+    public static final String METADATA_KEY = "metadata";
+
+    private final DeviceOperator parent;
+
+    private final DeviceModuleInfo module;
+
+    private final Mono<ConfigStorage> storage;
+
+    private final ThingTemplate template = new ModuleThingTemplate();
+
+    public DefaultDeviceModule(DeviceOperator parent,
+                               DeviceModuleInfo module,
+                               Mono<ConfigStorage> storage) {
+        this.parent = parent;
+        this.module = module;
+        this.storage = storage.cache();
+    }
+
+    private Mono<? extends org.jetlinks.core.metadata.DeviceMetadata> parentMetadata() {
+        return Mono.defer(() -> {
+            Mono<? extends org.jetlinks.core.metadata.DeviceMetadata> metadata = parent.getMetadata();
+            return metadata == null ? Mono.empty() : metadata;
+        });
+    }
+
+    @Override
+    public String getDeviceId() {
+        return module.getDeviceId() == null ? parent.getDeviceId() : module.getDeviceId();
+    }
+
+    @Override
+    public String getCode() {
+        return module.getCode();
+    }
+
+    @Override
+    public String getInstanceCode() {
+        return module.getInstanceCode();
+    }
+
+    @Override
+    public String getId() {
+        return module.getId();
+    }
+
+    @Override
+    public ThingType getType() {
+        return TYPE;
+    }
+
+    @Override
+    public Mono<? extends ThingTemplate> getTemplate() {
+        return Mono.just(template);
+    }
+
+    @Override
+    public Mono<Void> resetMetadata() {
+        return removeConfig(METADATA_KEY).then();
+    }
+
+    @Override
+    public Mono<? extends ThingMetadata> getMetadata() {
+        return getTemplateMetadata()
+            .flatMap(this::mergeSelfMetadata);
+    }
+
+    private Mono<ThingMetadata> getTemplateMetadata() {
+        return parentMetadata()
+            .mapNotNull(metadata -> metadata.getModule(module.getCode()).orElse(null));
+    }
+
+    private Mono<ThingMetadata> mergeSelfMetadata(ThingMetadata base) {
+        return getSelfConfig(METADATA_KEY)
+            .mapNotNull(Value::get)
+            .filter(this::hasMetadataValue)
+            .map(this::convertMetadata)
+            .map(base::merge)
+            .defaultIfEmpty(base);
+    }
+
+    private boolean hasMetadataValue(Object metadata) {
+        return !(metadata instanceof String) || StringUtils.hasText((String) metadata);
+    }
+
+    @SuppressWarnings("unchecked")
+    private ThingMetadata convertMetadata(Object metadata) {
+        if (metadata instanceof ThingMetadata) {
+            return (ThingMetadata) metadata;
+        }
+        if (metadata instanceof JSONObject) {
+            return new DefaultThingsMetadata((JSONObject) metadata);
+        }
+        if (metadata instanceof Map) {
+            return new DefaultThingsMetadata(new JSONObject((Map<String, Object>) metadata));
+        }
+        if (metadata instanceof String && StringUtils.hasText((String) metadata)) {
+            return new DefaultThingsMetadata(JSONObject.parseObject((String) metadata));
+        }
+        Object json = JSONObject.toJSON(metadata);
+        return json instanceof JSONObject
+            ? new DefaultThingsMetadata((JSONObject) json)
+            : new DefaultThingsMetadata(new JSONObject());
+    }
+
+    @Override
+    public Mono<Boolean> updateMetadata(String metadata) {
+        return Mono.defer(() -> setConfig(METADATA_KEY, parseMetadata(metadata)));
+    }
+
+    @Override
+    public Mono<Boolean> updateMetadata(ThingMetadata metadata) {
+        return setConfig(METADATA_KEY, metadata.toJson());
+    }
+
+    private Object parseMetadata(String metadata) {
+        return StringUtils.hasText(metadata) ? JSONObject.parseObject(metadata) : metadata;
+    }
+
+    @Override
+    public Mono<Value> getSelfConfig(String key) {
+        if (module.getConfiguration().containsKey(key)) {
+            return Mono.just(Value.simple(module.getConfiguration().get(key)));
+        }
+        return storage.flatMap(store -> store.getConfig(key));
+    }
+
+    @Override
+    public Mono<Values> getSelfConfigs(Collection<String> keys) {
+        return storage
+            .flatMap(store -> store.getConfigs(keys))
+            .defaultIfEmpty(Values.of(Map.of()))
+            .map(values -> {
+                Map<String, Object> merged = new LinkedHashMap<>(module.getConfiguration());
+                if (keys != null && !keys.isEmpty()) {
+                    merged.keySet().retainAll(keys);
+                }
+                merged.putAll(values.getAllValues());
+                return Values.of(merged);
+            });
+    }
+
+    @Override
+    public Mono<Value> getConfig(String key) {
+        return getSelfConfig(key).switchIfEmpty(parent.getConfig(key));
+    }
+
+    @Override
+    public Mono<Values> getConfigs(Collection<String> keys) {
+        return parent
+            .getConfigs(keys)
+            .defaultIfEmpty(Values.of(Map.of()))
+            .zipWith(getSelfConfigs(keys).defaultIfEmpty(Values.of(Map.of())), (parentValues, selfValues) -> {
+                Map<String, Object> merged = new LinkedHashMap<>(parentValues.getAllValues());
+                merged.putAll(selfValues.getAllValues());
+                return Values.of(merged);
+            });
+    }
+
+    @Override
+    public Mono<Boolean> setConfig(String key, Object value) {
+        return storage.flatMap(store -> store.setConfig(key, value));
+    }
+
+    @Override
+    public Mono<Boolean> setConfig(ConfigKeyValue<?> keyValue) {
+        return setConfig(keyValue.getKey(), keyValue.getValue());
+    }
+
+    @Override
+    public Mono<Boolean> setConfigs(Map<String, Object> conf) {
+        return storage.flatMap(store -> store.setConfigs(conf));
+    }
+
+    @Override
+    public Mono<Boolean> removeConfig(String key) {
+        return storage.flatMap(store -> store.remove(key));
+    }
+
+    @Override
+    public Mono<Value> getAndRemoveConfig(String key) {
+        return storage.flatMap(store -> store.getAndRemove(key));
+    }
+
+    @Override
+    public Mono<Boolean> removeConfigs(Collection<String> key) {
+        return storage.flatMap(store -> store.remove(key));
+    }
+
+    @Override
+    public Mono<Void> refreshConfig(Collection<String> keys) {
+        return storage.flatMap(store -> store.refresh(keys));
+    }
+
+    @Override
+    public Mono<Void> refreshAllConfig() {
+        return storage.flatMap(ConfigStorage::refresh);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> type) {
+        return type.isInstance(this) || parent.isWrapperFor(type);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> type) {
+        if (type.isInstance(this)) {
+            return type.cast(this);
+        }
+        return parent.unwrap(type);
+    }
+
+    @Override
+    public org.jetlinks.core.things.ThingRpcSupport rpc() {
+        return message -> parent.rpc().call(wrap(message));
+    }
+
+    private DeviceModuleMessage wrap(ThingMessage message) {
+        Message inner = message instanceof DeviceMessage
+            ? message.copy()
+            : message.copy().thingId(getType(), getId());
+        DeviceModuleMessage wrapper = new DeviceModuleMessage();
+        wrapper.deviceId(getDeviceId());
+        wrapper.module(getCode());
+        wrapper.moduleInstance(getInstanceCode());
+        wrapper.message(inner);
+        wrapper.timestamp(message.getTimestamp());
+        wrapper.messageId(message.getMessageId());
+        Map<String, Object> headers = message.getHeaders();
+        if (headers != null) {
+            headers.forEach(wrapper::addHeader);
+        }
+        wrapper.addHeader("module", getCode());
+        wrapper.addHeader("moduleInstance", getInstanceCode());
+        wrapper.addHeader(Headers.routeKey, getDeviceId());
+        return wrapper;
+    }
+
+    private class ModuleThingTemplate implements ThingTemplate {
+
+        @Override
+        public String getId() {
+            return getCode();
+        }
+
+        @Override
+        public Mono<? extends ThingMetadata> getMetadata() {
+            return getTemplateMetadata();
+        }
+
+        @Override
+        public Mono<Boolean> updateMetadata(String metadata) {
+            return Mono.error(new UnsupportedOperationException("unsupported update device module template metadata"));
+        }
+
+        @Override
+        public Mono<Boolean> updateMetadata(ThingMetadata metadata) {
+            return Mono.error(new UnsupportedOperationException("unsupported update device module template metadata"));
+        }
+
+        @Override
+        public Mono<Value> getConfig(String key) {
+            return parent.getConfig(key);
+        }
+
+        @Override
+        public Mono<Values> getConfigs(Collection<String> keys) {
+            return parent.getConfigs(keys);
+        }
+
+        @Override
+        public Mono<Boolean> setConfig(String key, Object value) {
+            return Mono.error(new UnsupportedOperationException("unsupported update device module template config"));
+        }
+
+        @Override
+        public Mono<Boolean> setConfigs(Map<String, Object> conf) {
+            return Mono.error(new UnsupportedOperationException("unsupported update device module template config"));
+        }
+
+        @Override
+        public Mono<Boolean> removeConfig(String key) {
+            return Mono.error(new UnsupportedOperationException("unsupported update device module template config"));
+        }
+
+        @Override
+        public Mono<Value> getAndRemoveConfig(String key) {
+            return Mono.error(new UnsupportedOperationException("unsupported update device module template config"));
+        }
+
+        @Override
+        public Mono<Boolean> removeConfigs(Collection<String> key) {
+            return Mono.error(new UnsupportedOperationException("unsupported update device module template config"));
+        }
+
+        @Override
+        public Mono<Void> refreshConfig(Collection<String> keys) {
+            return parent.refreshConfig(keys);
+        }
+
+        @Override
+        public Mono<Void> refreshAllConfig() {
+            return parent.refreshAllConfig();
+        }
+    }
+}

--- a/src/main/java/org/jetlinks/supports/device/DefaultDeviceModuleThingProvider.java
+++ b/src/main/java/org/jetlinks/supports/device/DefaultDeviceModuleThingProvider.java
@@ -1,0 +1,94 @@
+package org.jetlinks.supports.device;
+
+import org.jetlinks.core.config.ConfigKey;
+import org.jetlinks.core.config.ConfigStorageManager;
+import org.jetlinks.core.device.DeviceModule;
+import org.jetlinks.core.device.DeviceModuleThingProvider;
+import org.jetlinks.core.device.DeviceOperator;
+import org.springframework.core.ResolvableType;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * 通用设备模块物提供器.
+ * <p>
+ * 在微服务运行时没有设备管理本地服务时,可直接基于父设备物模型缓存和模块实例配置缓存
+ * 构造 {@link DeviceModule}。模块定义来自父设备物模型 {@code modules[id]}, 模块实例列表
+ * 来自父设备配置 {@link #MODULES_CONFIG_KEY}, 模块实例配置存储使用平台内部稳定模块实例ID。
+ *
+ * @author zhouhao
+ * @since 1.3.2
+ */
+public class DefaultDeviceModuleThingProvider implements DeviceModuleThingProvider {
+
+    /**
+     * 设备模块实例快照配置。
+     */
+    public static final ConfigKey<List<DeviceModuleInfo>> MODULES_CONFIG_KEY = ConfigKey.of(
+        "device.modules",
+        "设备模块实例列表",
+        ResolvableType.forClassWithGenerics(List.class, DeviceModuleInfo.class).getType()
+    );
+
+    private final ConfigStorageManager storageManager;
+
+    public DefaultDeviceModuleThingProvider(ConfigStorageManager storageManager) {
+        this.storageManager = storageManager;
+    }
+
+    @Override
+    public Flux<DeviceModule> getModuleThings(DeviceOperator device, String code) {
+        return device
+            .getMetadata()
+            .filter(metadata -> metadata.getModule(code).isPresent())
+            .flatMapMany(ignore -> getModuleInstances(device, code)
+                .map(module -> newModule(device, module)));
+    }
+
+    @Override
+    public Mono<DeviceModule> getModuleThing(DeviceOperator device, String code, String instanceCode) {
+        String actualInstanceCode = Objects.requireNonNullElse(instanceCode, code);
+        return device
+            .getMetadata()
+            .filter(metadata -> metadata.getModule(code).isPresent())
+            .flatMap(ignore -> getModuleInstances(device, code)
+                .filter(module -> actualInstanceCode.equals(module.getInstanceCode()))
+                .next()
+                .switchIfEmpty(Mono.fromSupplier(() -> fallback(device, code, actualInstanceCode)))
+                .map(module -> newModule(device, module)));
+    }
+
+    protected Flux<DeviceModuleInfo> getModuleInstances(DeviceOperator device, String code) {
+        return device
+            .getConfig(MODULES_CONFIG_KEY)
+            .flatMapMany(Flux::fromIterable)
+            .filter(module -> code.equals(module.getCode()))
+            .filter(module -> StringUtils.hasText(module.getInstanceCode()))
+            .switchIfEmpty(Flux.defer(() -> Flux.just(fallback(device, code, code))));
+    }
+
+    protected DeviceModuleInfo fallback(DeviceOperator device, String code, String instanceCode) {
+        DeviceModuleInfo info = new DeviceModuleInfo();
+        info.setId(device.getDeviceId() + ":" + instanceCode);
+        info.setDeviceId(device.getDeviceId());
+        info.setCode(code);
+        info.setInstanceCode(instanceCode);
+        return info;
+    }
+
+    protected DeviceModule newModule(DeviceOperator device, DeviceModuleInfo module) {
+        return new DefaultDeviceModule(
+            device,
+            module,
+            storageManager.getStorage(createStorageId(module))
+        );
+    }
+
+    protected String createStorageId(DeviceModuleInfo module) {
+        return "device-module:" + module.getId();
+    }
+}

--- a/src/main/java/org/jetlinks/supports/device/DeviceModuleInfo.java
+++ b/src/main/java/org/jetlinks/supports/device/DeviceModuleInfo.java
@@ -1,0 +1,82 @@
+package org.jetlinks.supports.device;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * 设备模块实例快照信息.
+ *
+ * @author zhouhao
+ * @since 1.3.2
+ */
+public class DeviceModuleInfo implements Serializable {
+
+    private String id;
+
+    private String deviceId;
+
+    private String code;
+
+    private String instanceCode;
+
+    private Map<String, Object> configuration;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public void setDeviceId(String deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getInstanceCode() {
+        return instanceCode;
+    }
+
+    public void setInstanceCode(String instanceCode) {
+        this.instanceCode = instanceCode;
+    }
+
+    public Map<String, Object> getConfiguration() {
+        return configuration == null ? Collections.emptyMap() : configuration;
+    }
+
+    public void setConfiguration(Map<String, Object> configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DeviceModuleInfo)) {
+            return false;
+        }
+        DeviceModuleInfo that = (DeviceModuleInfo) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/org/jetlinks/supports/official/DefaultThingsMetadata.java
+++ b/src/main/java/org/jetlinks/supports/official/DefaultThingsMetadata.java
@@ -29,7 +29,11 @@ public class DefaultThingsMetadata implements ThingMetadata {
 
     private volatile Map<String, PropertyMetadata> tags;
 
+    private volatile Map<String, ThingMetadata> modules;
+
     private volatile List<PropertyMetadata> propertyMetadataList;
+
+    private volatile List<ThingMetadata> moduleMetadataList;
 
     @Getter
     @Setter
@@ -52,7 +56,7 @@ public class DefaultThingsMetadata implements ThingMetadata {
     }
 
     public DefaultThingsMetadata(JSONObject jsonObject) {
-        this.jsonObject = jsonObject;
+        fromJson(jsonObject);
     }
 
     public DefaultThingsMetadata(ThingMetadata another) {
@@ -83,6 +87,12 @@ public class DefaultThingsMetadata implements ThingMetadata {
             .stream()
             .map(JetLinksPropertyMetadata::new)
             .collect(Collectors.toMap(JetLinksPropertyMetadata::getId, Function.identity(), (a, b) -> a, LinkedHashMap::new));
+
+        this.modules = another
+            .getModules()
+            .stream()
+            .map(DefaultThingsMetadata::new)
+            .collect(Collectors.toMap(DefaultThingsMetadata::getId, Function.identity(), (a, b) -> a, LinkedHashMap::new));
 
     }
 
@@ -183,6 +193,33 @@ public class DefaultThingsMetadata implements ThingMetadata {
     }
 
     @Override
+    public List<ThingMetadata> getModules() {
+        if (CollectionUtils.isNotEmpty(this.moduleMetadataList)) {
+            return this.moduleMetadataList;
+        }
+        if (this.modules == null && jsonObject != null) {
+            this.modules = Optional
+                .ofNullable(jsonObject.getJSONArray("modules"))
+                .map(Collection::stream)
+                .<Map<String, ThingMetadata>>map(stream -> stream
+                    .map(obj -> new DefaultThingsMetadata(toJSONObject(obj)))
+                    .collect(Collectors.toMap(
+                        ThingMetadata::getId,
+                        Function.identity(),
+                        (a, b) -> a,
+                        LinkedHashMap::new))
+                )
+                .orElse(Collections.emptyMap());
+        }
+
+        if (this.moduleMetadataList == null && this.modules != null) {
+            this.moduleMetadataList = Collections.unmodifiableList(new ArrayList<>(this.modules.values()));
+            return this.moduleMetadataList;
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
     public EventMetadata getEventOrNull(String id) {
         if (events == null) {
             getEvents();
@@ -253,6 +290,14 @@ public class DefaultThingsMetadata implements ThingMetadata {
         this.tags.put(metadata.getId(), new JetLinksPropertyMetadata(metadata));
     }
 
+    public void addModule(ThingMetadata metadata) {
+        if (this.modules == null) {
+            this.modules = new LinkedHashMap<>();
+        }
+        this.modules.put(metadata.getId(), new DefaultThingsMetadata(metadata));
+        this.moduleMetadataList = Collections.unmodifiableList(new ArrayList<>(this.modules.values()));
+    }
+
     public Map<String, Object> getExpands() {
         if (this.expands == null && jsonObject != null) {
             this.expands = jsonObject.getJSONObject("expands");
@@ -270,6 +315,7 @@ public class DefaultThingsMetadata implements ThingMetadata {
         json.put("functions", getFunctions().stream().map(Jsonable::toJson).collect(Collectors.toList()));
         json.put("events", getEvents().stream().map(Jsonable::toJson).collect(Collectors.toList()));
         json.put("tags", getTags().stream().map(Jsonable::toJson).collect(Collectors.toList()));
+        json.put("modules", getModules().stream().map(Jsonable::toJson).collect(Collectors.toList()));
         json.put("expands", expands);
         return json;
     }
@@ -281,6 +327,9 @@ public class DefaultThingsMetadata implements ThingMetadata {
         this.events = null;
         this.functions = null;
         this.tags = null;
+        this.modules = null;
+        this.propertyMetadataList = null;
+        this.moduleMetadataList = null;
         this.id = json.getString("id");
         this.name = json.getString("name");
         this.description = json.getString("description");
@@ -343,6 +392,14 @@ public class DefaultThingsMetadata implements ThingMetadata {
         for (PropertyMetadata tag : metadata.getTags()) {
             doMerge(deviceMetadata.tags, tag, PropertyMetadata::merge, options);
         }
+
+        if (deviceMetadata.modules == null) {
+            deviceMetadata.getModules();
+        }
+        for (ThingMetadata module : metadata.getModules()) {
+            doMerge(deviceMetadata.modules, new DefaultThingsMetadata(module), ThingMetadata::merge, options);
+        }
+        deviceMetadata.moduleMetadataList = null;
 
         return deviceMetadata;
     }

--- a/src/test/java/org/jetlinks/supports/device/DefaultDeviceModuleThingProviderTest.java
+++ b/src/test/java/org/jetlinks/supports/device/DefaultDeviceModuleThingProviderTest.java
@@ -1,0 +1,199 @@
+package org.jetlinks.supports.device;
+
+import com.alibaba.fastjson.JSONObject;
+import org.jetlinks.core.Value;
+import org.jetlinks.core.Values;
+import org.jetlinks.core.device.DeviceModule;
+import org.jetlinks.core.device.DeviceOperator;
+import org.jetlinks.core.message.Headers;
+import org.jetlinks.core.message.module.DeviceModuleMessage;
+import org.jetlinks.core.message.property.ReadPropertyMessage;
+import org.jetlinks.core.metadata.DeviceMetadata;
+import org.jetlinks.core.metadata.SimplePropertyMetadata;
+import org.jetlinks.core.metadata.types.StringType;
+import org.jetlinks.core.things.ThingMetadata;
+import org.jetlinks.supports.config.InMemoryConfigStorageManager;
+import org.jetlinks.supports.official.DefaultThingsMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DefaultDeviceModuleThingProviderTest {
+
+    @Test
+    public void testCreateModuleByParentMetadataAndInstanceStorage() {
+        DeviceOperator device = createDevice();
+        DefaultDeviceModuleThingProvider provider = new DefaultDeviceModuleThingProvider(new InMemoryConfigStorageManager());
+
+        StepVerifier.create(provider.getModuleThing(device, "board", "slot-1"))
+                    .assertNext(module -> {
+                        Assert.assertEquals("device-1", module.getDeviceId());
+                        Assert.assertEquals("board", module.getCode());
+                        Assert.assertEquals("slot-1", module.getInstanceCode());
+                        Assert.assertEquals("device-1:slot-1", module.getId());
+                    })
+                    .verifyComplete();
+    }
+
+    @Test
+    public void testModuleConfigUsesInstanceCacheAndFallbackParent() {
+        DeviceOperator device = createDevice();
+        when(device.getConfig("parentOnly")).thenReturn(Mono.just(Value.simple("parent")));
+        when(device.getConfigs(java.util.Set.of("parentOnly", "selfOnly")))
+            .thenReturn(Mono.just(Values.of(Map.of("parentOnly", "parent"))));
+
+        DefaultDeviceModuleThingProvider provider = new DefaultDeviceModuleThingProvider(new InMemoryConfigStorageManager());
+        DeviceModule module = provider.getModuleThing(device, "board", "slot-1").block();
+        Assert.assertNotNull(module);
+
+        StepVerifier.create(module.setConfig("selfOnly", "self"))
+                    .expectNext(true)
+                    .verifyComplete();
+        StepVerifier.create(module.getSelfConfig("selfOnly").map(Value::asString))
+                    .expectNext("self")
+                    .verifyComplete();
+        StepVerifier.create(module.getConfig("parentOnly").map(Value::asString))
+                    .expectNext("parent")
+                    .verifyComplete();
+        StepVerifier.create(module.getConfigs(java.util.Set.of("parentOnly", "selfOnly")))
+                    .assertNext(values -> {
+                        Assert.assertEquals("parent", values.getValue("parentOnly").get().asString());
+                        Assert.assertEquals("self", values.getValue("selfOnly").get().asString());
+                    })
+                    .verifyComplete();
+    }
+
+    @Test
+    public void testRpcWrapsModuleContextAndRouteKey() {
+        DeviceOperator device = createDevice();
+        when(device.rpc()).thenReturn(message -> Flux.just(message));
+        DefaultDeviceModuleThingProvider provider = new DefaultDeviceModuleThingProvider(new InMemoryConfigStorageManager());
+        DeviceModule module = provider.getModuleThing(device, "board", "slot-1").block();
+        Assert.assertNotNull(module);
+
+        ReadPropertyMessage message = new ReadPropertyMessage();
+        message.setDeviceId("device-1");
+        message.setMessageId("msg-1");
+        message.addHeader("module", "bad");
+        message.addHeader("moduleInstance", "bad");
+
+        StepVerifier.create(module.rpc().call(message))
+                    .assertNext(wrapper -> {
+                        Assert.assertTrue(wrapper instanceof DeviceModuleMessage);
+                        DeviceModuleMessage moduleMessage = (DeviceModuleMessage) wrapper;
+                        Assert.assertEquals("device-1", moduleMessage.getDeviceId());
+                        Assert.assertEquals("board", moduleMessage.getModule());
+                        Assert.assertEquals("slot-1", moduleMessage.getModuleInstance());
+                        Assert.assertEquals("device-1", moduleMessage.getHeaderOrElse(Headers.routeKey, null));
+                        Assert.assertEquals("board", moduleMessage.getHeaderOrElse("module", null));
+                        Assert.assertEquals("slot-1", moduleMessage.getHeaderOrElse("moduleInstance", null));
+                    })
+                    .verifyComplete();
+    }
+
+
+    @Test
+    public void testCreateModulesFromDeviceConfig() {
+        DeviceOperator device = createDevice();
+        when(device.getConfig(DefaultDeviceModuleThingProvider.MODULES_CONFIG_KEY))
+            .thenReturn(Mono.just(List.of(
+                moduleInfo("module-id-1", "board", "slot-1"),
+                moduleInfo("module-id-2", "board", "slot-2"),
+                moduleInfo("module-id-3", "network", "eth0")
+            )));
+        DefaultDeviceModuleThingProvider provider = new DefaultDeviceModuleThingProvider(new InMemoryConfigStorageManager());
+
+        StepVerifier.create(provider.getModuleThings(device, "board").map(DeviceModule::getInstanceCode))
+                    .expectNext("slot-1", "slot-2")
+                    .verifyComplete();
+        StepVerifier.create(provider.getModuleThing(device, "board", "slot-2"))
+                    .assertNext(module -> {
+                        Assert.assertEquals("slot-2", module.getInstanceCode());
+                        Assert.assertEquals("module-id-2", module.getId());
+                    })
+                    .verifyComplete();
+    }
+
+    @Test
+    public void testMissingModuleDefinitionReturnsEmpty() {
+        DeviceOperator device = createDevice();
+        DefaultDeviceModuleThingProvider provider = new DefaultDeviceModuleThingProvider(new InMemoryConfigStorageManager());
+
+        StepVerifier.create(provider.getModuleThing(device, "missing", "missing-1"))
+                    .verifyComplete();
+    }
+
+
+    @Test
+    public void testUpdateMetadataStoresParsedObjectAndMergesOnDemand() {
+        DeviceOperator device = createDevice();
+        DefaultDeviceModuleThingProvider provider = new DefaultDeviceModuleThingProvider(new InMemoryConfigStorageManager());
+        DeviceModule module = provider.getModuleThing(device, "board", "slot-1").block();
+        Assert.assertNotNull(module);
+
+        String customMetadata = "{\"id\":\"board\",\"properties\":[{\"id\":\"custom\",\"name\":\"自定义\",\"valueType\":{\"type\":\"string\"}}]}";
+        StepVerifier.create(module.updateMetadata(customMetadata))
+                    .expectNext(true)
+                    .verifyComplete();
+
+        StepVerifier.create(module.getSelfConfig(DefaultDeviceModule.METADATA_KEY).map(Value::get))
+                    .assertNext(value -> Assert.assertTrue(value instanceof JSONObject))
+                    .verifyComplete();
+        StepVerifier.create(module.getMetadata())
+                    .assertNext(metadata -> Assert.assertNotNull(metadata.getPropertyOrNull("custom")))
+                    .verifyComplete();
+    }
+
+    @Test
+    public void testModuleConfigurationMetadataSupportsThingMetadataObject() {
+        DeviceOperator device = createDevice();
+        DefaultThingsMetadata custom = new DefaultThingsMetadata("board", "控制板");
+        custom.addProperty(SimplePropertyMetadata.of("custom", "自定义", StringType.GLOBAL));
+        DeviceModuleInfo info = moduleInfo("module-id-1", "board", "slot-1");
+        info.setConfiguration(Map.of(DefaultDeviceModule.METADATA_KEY, custom));
+
+        when(device.getConfig(DefaultDeviceModuleThingProvider.MODULES_CONFIG_KEY))
+            .thenReturn(Mono.just(List.of(info)));
+
+        DefaultDeviceModuleThingProvider provider = new DefaultDeviceModuleThingProvider(new InMemoryConfigStorageManager());
+
+        StepVerifier.create(provider.getModuleThing(device, "board", "slot-1")
+                                    .flatMap(DeviceModule::getMetadata))
+                    .assertNext(metadata -> Assert.assertNotNull(metadata.getPropertyOrNull("custom")))
+                    .verifyComplete();
+    }
+
+
+    private DeviceModuleInfo moduleInfo(String id, String code, String instanceCode) {
+        DeviceModuleInfo info = new DeviceModuleInfo();
+        info.setId(id);
+        info.setDeviceId("device-1");
+        info.setCode(code);
+        info.setInstanceCode(instanceCode);
+        return info;
+    }
+
+    private DeviceOperator createDevice() {
+        ThingMetadata module = new DefaultThingsMetadata("board", "控制板");
+        DeviceMetadata metadata = mock(DeviceMetadata.class);
+        when(metadata.getModule("board")).thenReturn(Optional.of(module));
+        when(metadata.getModule("missing")).thenReturn(Optional.empty());
+
+        DeviceOperator device = mock(DeviceOperator.class);
+        when(device.getDeviceId()).thenReturn("device-1");
+        when(device.getMetadata()).thenReturn(Mono.just(metadata));
+        when(device.getConfig("parentOnly")).thenReturn(Mono.empty());
+        when(device.getConfig(DefaultDeviceModuleThingProvider.MODULES_CONFIG_KEY)).thenReturn(Mono.empty());
+        when(device.getConfigs(java.util.Set.of("parentOnly", "selfOnly"))).thenReturn(Mono.just(Values.of(Map.of())));
+        return device;
+    }
+}

--- a/src/test/java/org/jetlinks/supports/official/DefaultThingsMetadataModulesTest.java
+++ b/src/test/java/org/jetlinks/supports/official/DefaultThingsMetadataModulesTest.java
@@ -1,0 +1,54 @@
+package org.jetlinks.supports.official;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import org.jetlinks.core.things.ThingMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DefaultThingsMetadataModulesTest {
+
+    @Test
+    public void testDecodeAndEncodeModules() {
+        JSONObject json = JSON.parseObject("{\n" +
+            "  \"id\": \"device\",\n" +
+            "  \"name\": \"设备\",\n" +
+            "  \"properties\": [],\n" +
+            "  \"functions\": [],\n" +
+            "  \"events\": [],\n" +
+            "  \"tags\": [],\n" +
+            "  \"modules\": [{\n" +
+            "    \"id\": \"temperature-board\",\n" +
+            "    \"name\": \"温控板\",\n" +
+            "    \"properties\": [],\n" +
+            "    \"functions\": [],\n" +
+            "    \"events\": [],\n" +
+            "    \"tags\": []\n" +
+            "  }]\n" +
+            "}");
+
+        DefaultThingsMetadata metadata = new DefaultThingsMetadata(json);
+
+        Assert.assertEquals(1, metadata.getModules().size());
+        ThingMetadata module = metadata.getModule("temperature-board").orElse(null);
+        Assert.assertNotNull(module);
+        Assert.assertEquals("温控板", module.getName());
+
+        JSONObject encoded = metadata.toJson();
+        Assert.assertTrue(encoded.containsKey("modules"));
+        Assert.assertEquals(1, encoded.getJSONArray("modules").size());
+        Assert.assertEquals("temperature-board", encoded.getJSONArray("modules").getJSONObject(0).getString("id"));
+    }
+
+    @Test
+    public void testCopyKeepsModules() {
+        DefaultThingsMetadata metadata = new DefaultThingsMetadata("device", "设备");
+        metadata.addModule(new DefaultThingsMetadata("module-a", "模块A"));
+
+        DefaultThingsMetadata copied = new DefaultThingsMetadata(metadata);
+
+        Assert.assertEquals(1, copied.getModules().size());
+        Assert.assertNotNull(copied.getModuleOrNull("module-a"));
+        Assert.assertEquals(1, copied.toJson().getJSONArray("modules").size());
+    }
+}


### PR DESCRIPTION
## 本仓库范围

DefaultThingsMetadata modules 解析/编码/copy/merge、ClusterDeviceRegistry 注册模块 provider。

## 联动说明

本 PR 是设备模块能力多仓库联动发布的一部分。建议合并顺序：jetlinks-core -> jetlinks-supports -> jetlinks-components -> device-manager -> jetlinks-protocols。

---

# 设备模块能力生产发布

## 变更目的

为设备增加“模块”能力：模块归属于父设备，不作为子设备或独立物类型；模块可自定义编码，可通过 `DeviceOperator#getModuleThings(moduleCode)` 获取模块 `Thing`，并支持模块级物模型、读属性、写属性、功能调用、属性/事件历史存储与查询。

## 核心设计边界

1. 设备模块不是子设备，不参与独立认证、会话、在线状态、固件、子设备拓扑或独立资产权限。
2. 模块物模型只继承父设备/产品 metadata 中 `modules[moduleCode]` 对应模块物模型，不继承整机完整物模型。
3. 模块操作统一使用 `ThingModuleMessage` / `DeviceModuleMessage` 包装，内层属性、事件、功能 ID 不增加模块前缀。
4. 模块属性、模块事件使用独立 row-shaped 表；column mode 下模块数据也默认进入模块 row-shaped 表。
5. 模块日志不单独建表，继续复用父设备普通日志。
6. 模块数据查询提供专用 API，调用方不需要感知内部 `thingType`。
7. 事件值内部字段搜索不是本次交付能力；TimescaleDB `jsonb` 搜索为后续方言增强预留。
8. 未改造第三方/业务协议包不自动支持 `DeviceModuleMessage`，应按协议能力声明 unsupported 或能力缺失。

## 主要改动

- `dev/jetlinks/jetlinks-core`
  - `DeviceOperator#getModuleThings(moduleCode)` default unsupported。
  - `ThingMetadata#toJson()` 输出 `modules`。
  - 新增/接入 `DeviceModuleThingProvider`。

- `dev/jetlinks/jetlinks-supports`
  - `DefaultThingsMetadata` 支持 `modules` 解析、编码、copy、merge。
  - `ClusterDeviceRegistry` 接入模块 Thing provider。

- `modules/device-manager`
  - 新增 `DeviceModuleEntity`、`DeviceModuleService`、`DeviceModuleController`。
  - 新增 `DeviceModuleThing`、`DeviceModuleThingProvider`。
  - 新增 `DeviceModuleDataService`，提供模块属性/事件专用查询。
  - 模块 API 权限继承父设备资产权限。
  - 模块实例 metadata id 与模块编码一致性校验、`resetMetadata` 不存在模块 NotFound、重复模块编码友好错误。
  - 删除模块仅删除管理实体，不调用模块历史数据清理链路。
  - 补充 i18n、单元测试、设计/任务/发布文档。

- `jetlinks-components`
  - things-component 支持 `ThingModuleMessage` 模块属性/事件保存、查询、DDL、metric，并在模块属性/事件表中保留 `module` 与 `moduleInstance` 双维度。
  - column mode 下模块属性/事件默认进入模块 row-shaped 表。
  - timescaledb-component 支持模块表 DDL、模块维度索引和真实数据库验证。
  - configure-component 注册设备模块 provider。

- 协议包
  - 标准协议和官方协议支持 `/module/{moduleCode}/{instanceCode}/{innerTopic}`。
  - EventBus 完整设备消息 Topic 固定为 `/device/{productId}/{deviceId}/module/{moduleCode}/{instanceCode}/{innerTopic}`，单实例也必须显式包含 `{instanceCode}`。
  - 覆盖模块读属性、写属性、功能调用及 reply Topic。

## 历史数据策略

1. 删除模块管理实体不会物理删除已产生的模块属性、模块事件或父设备日志。
2. 模块历史数据仍按父设备 `deviceId`、产品表 `productId`、模块列 `module` 维度保留。
3. 未格式化历史事件查询可按 `deviceId + moduleCode + eventId` 查询已删除模块定义下的历史数据。
4. 格式化查询依赖当前父设备/产品物模型；模块定义删除后可能无法继续格式化历史值。

## 验证证据

### PR 包级 clean worktree 门禁

已在 detached clean worktree 上使用对齐后的目标基线重新执行：

```bash
DEVICE_MODULE_PR_BASE_REF_MAP='jetlinks-components=430b73d43' \
  bash .ai/device-module-release/run-pr-package-gates.sh
```

结果：`OK: device module PR package gates passed on detached clean worktrees.`

该门禁已覆盖 6 个 patch clean worktree apply、manifest 校验、发布 diff 边界审计、core/supports、device-manager、common/things、timescaledb、标准协议与官方协议测试。`jetlinks-components=430b73d43` 用于对齐 device-manager 既有 `CommonTagUtils` 依赖，不属于设备模块功能 patch。

已通过的发布材料边界证据：`verify-manifest.py` 输出 `patch_file_count=55`、`patch_not_in_release_count=0`，`status-summary.sh` 输出 `OK release materials are ready.`；同时已确认 EventBus topic 无 `/module/{code}/instance/{instanceCode}/...` 残留。

已通过测试：

```bash
./mvnw -f dev/jetlinks/pom.xml \
  -pl jetlinks-core,jetlinks-supports \
  -am \
  -Dtest=DefaultThingsMetadataModulesTest,DefaultDeviceOperatorTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```

结果：`BUILD SUCCESS`，`DefaultDeviceOperatorTest` 11 个测试通过，`DefaultThingsMetadataModulesTest` 2 个测试通过。

```bash
./mvnw -pl modules/device-manager \
  -Dtest=DeviceModuleControllerTest,DeviceModuleDataServiceTest,DeviceModuleServiceTest,DeviceModuleThingTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```

结果：`BUILD SUCCESS`，共 30 个测试通过。覆盖模块 CRUD/权限边界、metadata 合并与重置、重复编码与非法编码、运行时 Thing 包装、模块数据查询条件、删除模块保留历史数据调用边界。

```bash
./mvnw -pl jetlinks-components/things-component \
  -Dtest=ThingModuleMessageOperationsTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```

结果：`BUILD SUCCESS`，`ThingModuleMessageOperationsTest` 11 个测试通过。

```bash
./mvnw -pl jetlinks-components/timescaledb-component \
  -am \
  -Dtest=TimescaleDBModuleDataStrategyTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```

结果：`BUILD SUCCESS`，`TimescaleDBModuleDataStrategyTest` 1 个测试通过，Reactor 20 个模块 SUCCESS。该测试使用 Testcontainers 启动真实 TimescaleDB，覆盖模块表 DDL、索引、写入、查询和跨模块同名属性隔离，并断言不创建模块日志表。

```bash
./mvnw -f dev/jetlinks-protocols/jetlinks-protocol/pom.xml \
  -Dtest=StandardTopicMessageCodecTest \
  test
```

结果：`BUILD SUCCESS`，`StandardTopicMessageCodecTest` 10 个测试通过。

```bash
./mvnw -f dev/jetlinks-official-protocol/pom.xml \
  -Dtest=TopicMessageCodecTest \
  test
```

结果：`BUILD SUCCESS`，`TopicMessageCodecTest` 5 个测试通过。


### 2026-06-01 多实例 Topic 收口复核

本轮围绕 `/module/{code}/{instanceCode}/...` 与多实例模块模型重新生成发布 patch 和 manifest。

已通过：

```bash
python3 .ai/device-module-release/verify-manifest.py
bash .ai/device-module-release/status-summary.sh
bash .ai/device-module-release/self-test-apply-patches.sh
bash .ai/device-module-release/self-test-audit-release-diff.sh
```

结果摘要：`patch_file_count=55`、`patch_not_in_release_count=0`、`release_dependency_not_in_patch=-`，6 个 patch 均可在 detached clean worktree 上 `git apply --check`，diff 边界自检在 worktree/common-ref/per-repo-ref 三种模式下均为 `actual_diff_files=55 extra_files=0`。

针对性测试：

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) \
  mvn -f dev/jetlinks/jetlinks-core/pom.xml \
  -Dtest=DefaultDeviceOperatorTest,MessageTypeTest -DskipITs -P'!develop' test

JAVA_HOME=$(/usr/libexec/java_home -v 17) \
  mvn -f dev/jetlinks/jetlinks-supports/pom.xml \
  -Dtest=DefaultThingsMetadataModulesTest -DskipITs -P'!develop' test

JAVA_HOME=$(/usr/libexec/java_home -v 17) \
  ./mvnw -pl modules/device-manager \
  -Dtest=DeviceModuleServiceTest,DeviceModuleThingTest,DeviceMessageConnectorTest,DeviceModuleDataServiceTest,DeviceModuleControllerTest,DeviceThingsDataCustomizerTest \
  -Dsurefire.failIfNoSpecifiedTests=false -DskipITs -P'!develop' test
```

结果：core 21 个测试通过，supports 2 个测试通过，device-manager 50 个测试通过。

Topic/旧形态审计：未发现新增 `/module/{code}/instance/{instanceCode}`、`/module/{moduleCode}/instance/{instanceCode}` 或旧 `Mono<Thing> getModuleThing(String moduleCode)` API 正向残留；标准协议和官方协议均保留 `/module/*/*/**` 与 `/module/board/slot-1/...` 测试断言。

### 当前完整混合工作区完整矩阵补充

已执行：

```bash
bash .ai/device-module-release/verify-release.sh
```

结果：脚本内 core/supports、device-manager、things-component、timescaledb-component、标准协议、官方协议均 `BUILD SUCCESS`，输出 `========== 验证完成 ==========`。

注意：该证据来自当前完整混合工作区，只能作为功能闭环补充；若本 PR patch 继续在目标分支重放/合入，仍建议保留目标分支/CI 的 `run-release-gates.sh` 输出作为最终流水线记录。

### 正式发布分支要求

正式 PR 合并前，请在目标发布分支按实际门禁时机执行：

```bash
# patch 已应用但尚未提交：审计工作区 diff
bash .ai/device-module-release/run-release-gates.sh

# patch 已作为提交进入当前分支/CI：审计 <目标基线>...HEAD
DEVICE_MODULE_BASE_REF=<目标基线> bash .ai/device-module-release/run-release-gates.sh
```

如 CI 需要拆分步骤，可等价执行：

```bash
python3 .ai/device-module-release/verify-manifest.py
bash .ai/device-module-release/self-test-apply-patches.sh
bash .ai/device-module-release/verify-release.sh
bash .ai/device-module-release/self-test-audit-release-diff.sh
python3 .ai/device-module-release/audit-release-diff.py

# patch 已提交时，最后一步必须带 base ref 或设置 DEVICE_MODULE_BASE_REF
python3 .ai/device-module-release/audit-release-diff.py --base-ref <目标基线>
```

多仓库目标基线不一致时，应使用：

```bash
DEVICE_MODULE_BASE_REF_MAP='.=origin/2.10;modules/device-manager=origin/master;jetlinks-components=origin/master;dev/jetlinks/jetlinks-core=origin/master;dev/jetlinks/jetlinks-supports=origin/master;dev/jetlinks-protocols=origin/master;dev/jetlinks-official-protocol=origin/master' \
  bash .ai/device-module-release/run-release-gates.sh
```

并将输出结果补充到本 PR 描述或 CI 记录中。其中 `verify-manifest.py` 必须输出 `OK: release manifest verified.`，`self-test-apply-patches.sh` 必须输出全部 patch 正向或反向 `apply --check` 通过，`verify-release.sh` 必须全部 `BUILD SUCCESS`，`self-test-audit-release-diff.sh` 必须同时覆盖 `worktree-diff` 与 `committed-diff` 且输出 `actual_diff_files=55 extra_files=0`，`audit-release-diff.py` 必须输出 `extra_files=0`。如果 patch 已提交进入当前分支，`audit-release-diff.py` 还必须输出 `audit_mode=committed-diff` 和正确的 `base_ref` 或 `base_ref_map`。

## 文档同步

已同步：

- `modules/device-manager/docs/2026-05-30-device-module-design.md`
- `modules/device-manager/docs/2026-05-30-device-module-development-tasks.md`
- `modules/device-manager/docs/2026-05-30-device-module-release-notes.md`
- `modules/device-manager/docs/2026-05-30-device-module-release-file-list.md`

## 发布边界检查

本 PR 应只包含设备模块发布清单中的文件。不得混入：

- 集群/RPC、限流、指标/健康度、向量检索等无关组件改动。
- GB26875、大华、JTT809、SZY206 等非本次验证协议包改动。
- 微服务配置、静态资源、运行配置、临时文件等无关改动。

## 残余风险 / 非目标项

1. 未改造协议包不自动支持模块消息。
2. 事件值内部字段搜索未交付；如需支持，应单独实现 TimescaleDB/PostgreSQL `jsonb` 方言查询和索引验证。
3. 当前已有 controller 单元级权限短路验证，并覆盖删除模块不调用历史数据清理链路；如果组织门禁要求设备模块 controller 自身完整 HTTP/WebFlux 鉴权链路测试，需要额外补集成测试。


## 2026-06-02 补充验证记录

- 已将模块数据存储与查询补齐 `moduleInstance` 维度：保存行、DDL、查询条件、数据 ID 均包含模块实例编码。
- `QueryOperations` 保留旧单实例方法并委托到 `moduleInstance = module`，新增显式实例重载供 `DeviceModuleDataService` 调用。
- PR 包级 clean worktree 门禁已使用 `DEVICE_MODULE_PR_BASE_REF_MAP='jetlinks-components=430b73d43'` 通过，完整生产结论以该 clean worktree gate 与目标分支/CI 后续 `run-release-gates.sh` 为准。


补充通过的本地 targeted tests（2026-06-02）：

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) \
  mvn -f jetlinks-components/pom.xml \
  -pl common-component,things-component \
  -Dtest=ThingModuleMessageOperationsTest \
  -Dsurefire.failIfNoSpecifiedTests=false -DskipITs -P'!develop' test
```

结果：`BUILD SUCCESS`，`ThingModuleMessageOperationsTest` 14 个测试通过。

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) \
  mvn -f jetlinks-components/pom.xml \
  -pl common-component,things-component \
  -DskipTests -DskipITs -P'!develop' install

JAVA_HOME=$(/usr/libexec/java_home -v 17) \
  ./mvnw -pl modules/device-manager \
  -Dtest=DeviceModuleDataServiceTest,DeviceMessageConnectorTest \
  -Dsurefire.failIfNoSpecifiedTests=false -DskipITs -P'!develop' test
```

结果：`BUILD SUCCESS`，`DeviceMessageConnectorTest` 5 个、`DeviceModuleDataServiceTest` 4 个测试通过。
