### PR TITLE
perf(配置缓存): 优化一级缓存命中性能

### DIFF
--- a/docs/plans/local-cache-cluster-config-storage-performance.md
+++ b/docs/plans/local-cache-cluster-config-storage-performance.md
@@ -1,0 +1,64 @@
+# LocalCacheClusterConfigStorage 稳态读取优化
+
+## 目标与范围
+
+- owning module：`jetlinks-supports`
+- 优化入口：`src/main/java/org/jetlinks/supports/config/LocalCacheClusterConfigStorage.java`
+- 目标：降低 `getConfigs` 一级缓存命中路径的 CPU 与瞬时分配，不修改 Core SPI、
+  Redis 二级缓存协议、集群失效通知和缓存版本语义。
+- 不引入跨消息 Header/配置快照缓存，也不使用额外 Reactor 操作符包装同步读取。
+
+## 实现
+
+1. `getOrCreateCache` 先执行无分配的 `Map.get`，仅在首次创建时进入
+   `computeIfAbsent`。
+2. `getConfigs` 延迟创建结果 Map，只保存非 null 配置，直接构造 `Values`，移除
+   `Maps.filterValues` 视图及其迭代器。
+3. 全负缓存或空结果复用不可变 `Values` 与 `Mono`。
+4. 二级缓存未命中完成时同样复用空 `Values`；正、负、混合命中仍写入原有
+   `Cache`，后续读取不重复访问 L2。
+
+负缓存继续表现为“配置不存在”，不会通过 `Values.getValue` 或
+`Values.getAllValues` 暴露 null 值。并发加载、版本比较和
+`CacheNotify` 集群失效路径未修改。
+
+## 验证
+
+基准提交为 `3ead6e2`。JMH 使用 JDK 21、2 forks、3 次 1 秒预热、5 次 1 秒测量和
+GC profiler；结果文件由以下测试基准生成：
+
+`src/test/java/org/jetlinks/supports/config/LocalCacheClusterConfigStorageBenchmark.java`
+
+| 场景 | 耗时（ns/op）基准 → 优化 | 耗时变化 | 分配（B/op）基准 → 优化 | 分配变化 |
+| --- | ---: | ---: | ---: | ---: |
+| 8 个正缓存命中 | 200.831 → 142.605 | -28.99% | 656.026 → 416.020 | -36.58% |
+| 8 个正负混合命中 | 203.033 → 120.901 | -40.45% | 656.028 → 352.017 | -46.34% |
+| 1 个负缓存命中 | 44.049 → 6.059 | -86.24% | 264.009 → 0 | -100% |
+| 7 个 L1 命中、1 个 L2 加载 | 6870.716 → 6752.521 | -1.72% | 3608.189 → 3456.186 | -4.21% |
+| 8 个 L2 加载 | 7537.341 → 7590.114 | +0.70%（噪声） | 5128.205 → 5080.228 | -0.94% |
+
+Components 设备消息真实链路使用同一代码、数据集和 classpath，仅替换从
+`3ead6e2` 构建的 Supports jar 与优化 jar。环境为 4C8G、8 个入口 worker、4 个
+Reactor worker、14,000 msg/s、真实 `EventBusStorageManager -> Redis`，设备链路
+包含 5000 个组织、200 个用户、每用户 500 个组织和 10000 个设备。
+
+- `route-only`：3 组交替 A/B，每组 30 秒预热、60 秒测量。配对中位数 CPU
+  下降 1.55%；分配下降 18.20%。三组结果均为 840,000 输入、3,360,000 投递，
+  queue `0 -> 0`，零 drop/error/重复/乱序，checksum 一致。
+- `full-platform`：120 秒预热、60 秒测量的补充 A/B。CPU
+  `223,667 -> 221,488 ns/input`（-0.97%），分配
+  `15,853 -> 13,808 B/input`（-12.90%），processing p50
+  `0.289 -> 0.260 ms`；840,000 输入、18,480,000 投递和 1,680,000 durable
+  writes 全部正确，queue `0 -> 0`，三个 buffer 完全排空。单组 CPU/延迟仅作为
+  完整链路佐证，稳定收益以分配和 route-only 三组 A/B 为主。
+
+定向测试：
+
+```bash
+mvn -o -Dtest=LocalCacheClusterConfigStorageTest,EventBusStorageManagerTest test
+```
+
+共 15 个测试通过，覆盖正缓存、负缓存、正负混合、部分失效、Redis 与集群通知。
+全量 `mvn -o test` 运行到 38 个测试时仅
+`DetailErrorMapperTest.testRoundTripConversion` 失败；在未修改的 `3ead6e2`
+独立 worktree 中可稳定复现，确认与本次缓存优化无关。

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,20 @@
         </dependency>
 
         <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.35</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.35</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
         </dependency>

--- a/src/main/java/org/jetlinks/supports/config/LocalCacheClusterConfigStorage.java
+++ b/src/main/java/org/jetlinks/supports/config/LocalCacheClusterConfigStorage.java
@@ -56,6 +56,10 @@ public class LocalCacheClusterConfigStorage implements ConfigStorage {
 
     public static final Value NULL = Value.simple(null);
 
+    private static final Values EMPTY_VALUES = Values.of(Collections.emptyMap());
+
+    private static final Mono<Values> EMPTY_VALUES_MONO = Mono.just(EMPTY_VALUES);
+
     private final Map<String, Cache> caches;
     final String id;
     private final EventBusStorageManager manager;
@@ -112,8 +116,11 @@ public class LocalCacheClusterConfigStorage implements ConfigStorage {
     }
 
     private Cache getOrCreateCache(String key) {
-        return caches
-            .computeIfAbsent(key, this::createCache);
+        Cache cache = caches.get(key);
+        if (cache != null) {
+            return cache;
+        }
+        return caches.computeIfAbsent(key, this::createCache);
     }
 
     @Override
@@ -129,8 +136,8 @@ public class LocalCacheClusterConfigStorage implements ConfigStorage {
 
     @Override
     public Mono<Values> getConfigs(Collection<String> keys) {
-        int hits = 0;
-        Map<String, Object> loaded = Maps.newHashMapWithExpectedSize(keys.size());
+        int remaining = keys.size();
+        Map<String, Object> loaded = null;
         //获取二级缓存中加载的配置
         Map<String, Cache> cacheLoaded = null;
         for (String key : keys) {
@@ -138,19 +145,29 @@ public class LocalCacheClusterConfigStorage implements ConfigStorage {
             Value cached = local.getCached();
             if (cached != null) {
                 //命中一级缓存
-                hits++;
-                loaded.put(key, cached.get());
+                Object value = cached.get();
+                if (value != null) {
+                    if (loaded == null) {
+                        loaded = Maps.newHashMapWithExpectedSize(keys.size());
+                    }
+                    loaded.put(key, value);
+                }
             } else {
                 if (cacheLoaded == null) {
-                    cacheLoaded = Maps.newHashMapWithExpectedSize(keys.size() - hits);
+                    cacheLoaded = Maps.newHashMapWithExpectedSize(remaining);
                 }
                 cacheLoaded.put(key, local);
             }
+            remaining--;
         }
-        Values wrap = Values.of(Maps.filterValues(loaded, Objects::nonNull));
         //全部来自一级缓存则直接返回
-        if (hits == keys.size() || cacheLoaded == null) {
-            return Mono.just(wrap);
+        if (cacheLoaded == null) {
+            return loaded == null
+                ? EMPTY_VALUES_MONO
+                : Mono.just(Values.of(loaded));
+        }
+        if (loaded == null) {
+            loaded = Maps.newHashMapWithExpectedSize(cacheLoaded.size());
         }
 
         //需要从二级缓存中加载的配置
@@ -390,7 +407,7 @@ public class LocalCacheClusterConfigStorage implements ConfigStorage {
                     }
                 }
             }
-            actual.onNext(Values.of(container));
+            actual.onNext(container.isEmpty() ? EMPTY_VALUES : Values.of(container));
             actual.onComplete();
         }
 

--- a/src/test/java/org/jetlinks/supports/config/LocalCacheClusterConfigStorageBenchmark.java
+++ b/src/test/java/org/jetlinks/supports/config/LocalCacheClusterConfigStorageBenchmark.java
@@ -1,0 +1,155 @@
+package org.jetlinks.supports.config;
+
+import org.jetlinks.core.Values;
+import org.jetlinks.core.cluster.ClusterCache;
+import org.openjdk.jmh.annotations.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link LocalCacheClusterConfigStorage#getConfigs(Collection)} micro benchmark.
+ *
+ * The hit scenarios measure the production L1 path without a mock invocation in the measured
+ * operation. Miss scenarios retain the mocked L2 boundary so that map assembly and subscriber
+ * behavior remain covered without introducing an external Redis dependency.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class LocalCacheClusterConfigStorageBenchmark {
+
+    @Benchmark
+    public Values positiveHit8(PositiveHitState state) {
+        return state.storage.getConfigs(state.keys).block();
+    }
+
+    @Benchmark
+    public Values negativeHit1(NegativeHitState state) {
+        return state.storage.getConfigs(state.keys).block();
+    }
+
+    @Benchmark
+    public Values mixedHit8(MixedHitState state) {
+        return state.storage.getConfigs(state.keys).block();
+    }
+
+    @Benchmark
+    public Values partialMiss8(PartialMissState state) {
+        return state.storage.getConfigs(state.keys).block();
+    }
+
+    @Benchmark
+    public Values allMiss8(AllMissState state) {
+        return state.storage.getConfigs(state.keys).block();
+    }
+
+    abstract static class BaseState {
+        LocalCacheClusterConfigStorage storage;
+        List<String> keys;
+        Map<String, Object> backend;
+
+        void initialize(int presentKeys) {
+            keys = Arrays.asList("k0", "k1", "k2", "k3", "k4", "k5", "k6", "k7");
+            backend = new HashMap<>();
+            for (int i = 0; i < presentKeys; i++) {
+                backend.put(keys.get(i), "value-" + i);
+            }
+
+            @SuppressWarnings("unchecked")
+            ClusterCache<String, Object> clusterCache = mock(ClusterCache.class);
+            when(clusterCache.get(any(Collection.class)))
+                .thenAnswer(invocation -> load(invocation.getArgument(0)));
+
+            EventBusStorageManager manager = mock(EventBusStorageManager.class);
+            when(manager.doNotify(any())).thenReturn(Mono.empty());
+
+            storage = new LocalCacheClusterConfigStorage(
+                "benchmark",
+                manager,
+                clusterCache,
+                -1,
+                null,
+                new ConcurrentHashMap<>()
+            );
+        }
+
+        private Flux<Map.Entry<String, Object>> load(Collection<String> requested) {
+            return Flux
+                // ClusterCache owns the request collection after get(Collection) returns. Snapshot
+                // it here just as a remote implementation does before emitting entries.
+                .fromIterable(new ArrayList<>(requested))
+                .filter(backend::containsKey)
+                .map(key -> new AbstractMap.SimpleImmutableEntry<>(key, backend.get(key)));
+        }
+
+        void warmCache() {
+            storage.getConfigs(keys).block();
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class PositiveHitState extends BaseState {
+        @Setup(Level.Trial)
+        public void setup() {
+            initialize(8);
+            warmCache();
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class NegativeHitState extends BaseState {
+        @Setup(Level.Trial)
+        public void setup() {
+            initialize(0);
+            keys = Collections.singletonList("missing");
+            warmCache();
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class MixedHitState extends BaseState {
+        @Setup(Level.Trial)
+        public void setup() {
+            initialize(6);
+            warmCache();
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class PartialMissState extends BaseState {
+        @Setup(Level.Trial)
+        public void setup() {
+            initialize(8);
+            warmCache();
+        }
+
+        @Setup(Level.Invocation)
+        public void expireOneKey() {
+            storage.clearLocalCache(CacheNotify.expires("benchmark", Collections.singleton("k7")));
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class AllMissState extends BaseState {
+        @Setup(Level.Trial)
+        public void setup() {
+            initialize(8);
+            warmCache();
+        }
+
+        @Setup(Level.Invocation)
+        public void expireAllKeys() {
+            storage.clearLocalCache(CacheNotify.expires("benchmark", keys));
+        }
+    }
+}

--- a/src/test/java/org/jetlinks/supports/config/LocalCacheClusterConfigStorageTest.java
+++ b/src/test/java/org/jetlinks/supports/config/LocalCacheClusterConfigStorageTest.java
@@ -14,8 +14,13 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -29,6 +34,125 @@ import static org.mockito.Mockito.*;
 
 @Slf4j
 public class LocalCacheClusterConfigStorageTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetConfigsPositiveHitDoesNotReload() {
+        Map<String, Object> backend = new HashMap<>();
+        backend.put("id", "device-1");
+        backend.put("name", "demo");
+        ClusterCache<String, Object> clusterCache = createClusterCache(backend);
+        LocalCacheClusterConfigStorage storage = createStorage(clusterCache);
+        List<String> keys = Arrays.asList("id", "name");
+
+        Values first = storage.getConfigs(keys).block();
+        Values second = storage.getConfigs(keys).block();
+
+        assertNotNull(first);
+        assertNotNull(second);
+        assertEquals(backend, first.getAllValues());
+        assertEquals(backend, second.getAllValues());
+        verify(clusterCache, times(1)).get(anyCollection());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetConfigsNegativeHitDoesNotReload() {
+        ClusterCache<String, Object> clusterCache = createClusterCache(Collections.emptyMap());
+        LocalCacheClusterConfigStorage storage = createStorage(clusterCache);
+        List<String> keys = Arrays.asList("missing-1", "missing-2");
+
+        Values first = storage.getConfigs(keys).block();
+        Values second = storage.getConfigs(keys).block();
+
+        assertNotNull(first);
+        assertNotNull(second);
+        assertTrue(first.isEmpty());
+        assertTrue(second.isEmpty());
+        assertTrue(first.getAllValues().isEmpty());
+        assertTrue(second.getAllValues().isEmpty());
+        verify(clusterCache, times(1)).get(anyCollection());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetConfigsMixedHitDoesNotExposeNegativeCache() {
+        Map<String, Object> backend = new HashMap<>();
+        backend.put("id", "device-1");
+        backend.put("name", "demo");
+        ClusterCache<String, Object> clusterCache = createClusterCache(backend);
+        LocalCacheClusterConfigStorage storage = createStorage(clusterCache);
+        List<String> keys = Arrays.asList("id", "missing-1", "name", "missing-2");
+
+        Values first = storage.getConfigs(keys).block();
+        Values second = storage.getConfigs(keys).block();
+
+        assertNotNull(first);
+        assertNotNull(second);
+        assertEquals(backend, first.getAllValues());
+        assertEquals(backend, second.getAllValues());
+        assertFalse(first.getAllValues().containsKey("missing-1"));
+        assertFalse(second.getAllValues().containsKey("missing-2"));
+        verify(clusterCache, times(1)).get(anyCollection());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetConfigsReloadsOnlyExpiredKey() {
+        Map<String, Object> backend = new HashMap<>();
+        backend.put("id", "device-1");
+        backend.put("name", "demo");
+        backend.put("productId", "product-1");
+        List<List<String>> requests = new ArrayList<>();
+        ClusterCache<String, Object> clusterCache = createClusterCache(backend, requests);
+        LocalCacheClusterConfigStorage storage = createStorage(clusterCache);
+        List<String> keys = Arrays.asList("id", "name", "productId");
+
+        assertEquals(backend, storage.getConfigs(keys).block().getAllValues());
+        storage.clearLocalCache(CacheNotify.expires("test", Collections.singleton("name")));
+        assertEquals(backend, storage.getConfigs(keys).block().getAllValues());
+
+        verify(clusterCache, times(2)).get(anyCollection());
+        assertEquals(keys.size(), requests.get(0).size());
+        assertTrue(requests.get(0).containsAll(keys));
+        assertEquals(Collections.singletonList("name"), requests.get(1));
+    }
+
+    private static LocalCacheClusterConfigStorage createStorage(ClusterCache<String, Object> clusterCache) {
+        EventBusStorageManager manager = mock(EventBusStorageManager.class);
+        when(manager.doNotify(any())).thenReturn(Mono.empty());
+        return new LocalCacheClusterConfigStorage(
+            "test",
+            manager,
+            clusterCache,
+            -1,
+            null,
+            new ConcurrentHashMap<>()
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ClusterCache<String, Object> createClusterCache(Map<String, Object> backend) {
+        return createClusterCache(backend, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ClusterCache<String, Object> createClusterCache(Map<String, Object> backend,
+                                                                    List<List<String>> requests) {
+        ClusterCache<String, Object> clusterCache = mock(ClusterCache.class);
+        when(clusterCache.get(anyCollection())).thenAnswer(invocation -> {
+            Collection<String> requested = invocation.getArgument(0);
+            List<String> snapshot = new ArrayList<>(requested);
+            if (requests != null) {
+                requests.add(snapshot);
+            }
+            return Flux
+                .fromIterable(snapshot)
+                .filter(backend::containsKey)
+                .map(key -> new AbstractMap.SimpleImmutableEntry<>(key, backend.get(key)));
+        });
+        return clusterCache;
+    }
 
     @Test
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## 目的

- 降低 `LocalCacheClusterConfigStorage#getConfigs` 稳态一级缓存命中路径的 CPU 与瞬时分配。
- 优化设备消息 Header 配置读取等高频调用，同时保持 Core SPI、Redis L2 和集群失效语义不变。

## 核心变动

- 模块 / 文件：`LocalCacheClusterConfigStorage`、对应单元测试与 JMH 基准。
- 行为变化：L1 命中先走 `Map.get`；结果 Map 延迟创建且只保存非 null 配置；空结果复用不可变 `Values/Mono`；移除 `Maps.filterValues` 视图。
- 边界或约束变化：不新增跨消息配置缓存，不改变缓存版本、并发加载、Redis 协议及 `CacheNotify` 集群同步。
- 阶段提交：`4681a17 perf(配置缓存): 优化一级缓存命中性能`

## 设计与测试目标

- 任务契约：`docs/plans/local-cache-cluster-config-storage-performance.md`
- 权威文档：已同步上述性能设计与验证文档；Core SPI 和公共配置契约未变。
- 用户确认：已确认实施并提交评审 PR。
- 测试目标：覆盖正缓存、负缓存、正负混合、部分 L1 失效、全 L2 加载、Redis 集成及真实设备消息完整链路。
- 注释 / 公共契约：不涉及新增公共 SPI；热路径分支命名和既有注释已能表达语义，JMH 基准已补充测量边界说明。
- 数据权限：不适用；未涉及资产查询或操作权限。
- 数据库兼容与性能：不适用；未涉及 SQL。Redis 使用现有 `ClusterCache` 契约。
- 链路追踪：不适用；未新增异步边界或外部调用，现有链路追踪行为不变。
- MBean 运维可观测性：沿用 `EventBusStorageManager` 现有 MBean；未新增缓存实例、队列或后台任务。
- 系统性求解：通过 JFR 确认 HashMap、`Maps.filterValues` 和方法引用为 L1 分配热点，并验证正、负、混合命中及 L2 边界；未保留特调或 fallback。

## 测试结果

- 测试命令：`mvn -o -Dtest=LocalCacheClusterConfigStorageTest,EventBusStorageManagerTest test`；`mvn -o -DskipTests -Djacoco.skip=true package`
- 证据来源与复用判断：本地阶段验证，对应提交 `4681a17` 的同一 Git tree；提交后仅 HEAD 元数据变化，生产代码、测试、依赖和基准配置未变化，证据继续有效。
- 新增/更新测试：新增 4 个 `getConfigs` 语义回归用例和 5 场景 JMH；更新 `LocalCacheClusterConfigStorageTest`。
- 单元测试：15 个通过，0 失败，0 跳过。全量测试中的 `DetailErrorMapperTest.testRoundTripConversion` 在未修改的 `3ead6e2` worktree 可稳定复现，与本 PR 无关。
- 集成测试结果或不适用原因：`EventBusStorageManagerTest` 使用真实 Redis Testcontainers，2 个用例通过；Components 真实 `EventBusStorageManager -> Redis` 4C8G 链路零 drop/error/重复/乱序。
- 压力测试结果或不适用原因：JMH 中正命中耗时 -28.99%、分配 -36.58%，混合命中耗时 -40.45%、分配 -46.34%，负命中达到 0 B/op。4C8G route-only 三组配对中位 CPU -1.55%、分配 -18.20%；full-platform 分配 -12.90%、CPU -0.97%。
- 覆盖率：JaCoCo 中 `LocalCacheClusterConfigStorage` 外层类 line 86.4%、branch 78.8%；另以真实 Redis 和 4C8G 完整链路补充验证响应式及集群边界。

## 文档同步情况

- 已同步：`docs/plans/local-cache-cluster-config-storage-performance.md`
- 未同步：无。
- 说明：文档保留稳定实现边界与可复用基准结论；原始测试日志保留在本地构建产物中。

## 风险与说明

- 影响范围：所有使用 `LocalCacheClusterConfigStorage` 的配置批量读取方，主要收益位于稳态 L1 命中路径。
- 兼容性与发布边界：Core SPI、返回类型和缓存失效契约不变；负缓存继续表现为配置不存在，不暴露 null 配置项。
- 注释 / 公共契约：不涉及新增或修改 SPI；已补基准类测量边界注释。
- 数据库兼容与 SQL 性能：不涉及。
- 链路追踪 / 可观测性：现有平台追踪与缓存管理指标不变。
- MBean / 运维可观测性：沿用现有 `EventBusStorageManager` MBean。
- 未覆盖场景：未执行跨物理节点 Redis 网络故障注入；本次未修改该链路。
- 已知限制：L2 miss 微基准包含 mocked ClusterCache 开销，因此 L2 结论以真实 Redis 集成和完整链路结果为准。
- 回滚方式：回滚提交 `4681a17` 即可，不涉及数据迁移或配置变更。
